### PR TITLE
fix(backend): resolve reasoning content support via builtin declarations and actual served model

### DIFF
--- a/backend/core/ai_protocol/models.py
+++ b/backend/core/ai_protocol/models.py
@@ -411,6 +411,13 @@ class UnifiedResponseMeta:
     # Context window (tokens) of the winning candidate that actually served
     # the request, so callers budget against the real model, not the primary.
     context_window_tokens: int | None = None
+    # 实际服务候选（winner）的有效能力集（已应用 ai_model_override 覆盖），
+    # 供调用方按实际 winner 判断 reasoning_content 等字段是否可回传，
+    # 而不是退回目录默认能力（Issue #529）。
+    # Effective capabilities (post ai_model_override) of the winning
+    # candidate, so callers replay fields like reasoning_content based on
+    # the real winner instead of catalog defaults.
+    served_capabilities: ModelCapabilitySet | None = None
 
 
 class _AttributeProxy:

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -856,22 +856,58 @@ class StrategyConfig:
     def is_model_supports_reasoning_content(self, model_name: str) -> bool:
         """检查模型是否支持 reasoning_content 字段
 
+        优先按内置模型目录（ai_providers.py BuiltinModel）的能力声明判定，
+        覆盖 deepseek-v4 / glm / qwen / kimi 等声明 reasoning_content=True
+        的现役推理模型；目录未覆盖的自定义模型回退到 DeepSeek-R1 系列
+        前缀匹配，保持对历史自定义模型名的兼容（Issue #529）。
+
         Args:
-            model_name: 模型名称（如 'deepseek-r1', 'glm-4.7'）
+            model_name: 模型名称（如 'deepseek-v4-flash', 'glm-4.7'）
 
         Returns:
             True 如果模型支持 reasoning_content
         """
-        # DeepSeek-R1 系列模型支持 reasoning_content
+        model_lower = model_name.lower().strip()
+        if not model_lower:
+            return False
+
+        reasoning_ids, known_ids = _builtin_reasoning_capability_index()
+        if model_lower in known_ids:
+            return model_lower in reasoning_ids
+
+        # 目录未命中的自定义模型：DeepSeek-R1 系列前缀回退（目录内
+        # deepseek-r1 系列已弃用，自定义端点可能仍暴露这些名称）
         deepseek_models = [
             "deepseek-r1",
             "deepseek-reasoner",
             "deepseek-r1-lite",
             "deepseek-r1-zero",
         ]
-
-        model_lower = model_name.lower()
         return any(model_lower.startswith(ds_model) for ds_model in deepseek_models)
+
+
+@lru_cache
+def _builtin_reasoning_capability_index() -> tuple[frozenset[str], frozenset[str]]:
+    """内置模型目录的 reasoning_content 能力索引。
+
+    返回 (支持模型的 id/别名集合, 目录内全部 id/别名集合)。ai_providers.py
+    的 BuiltinModel 声明是模型能力的单一来源；延迟导入以避免模块初始化
+    顺序耦合。
+    """
+    from backend.core.ai_providers import list_builtin_providers
+
+    reasoning_ids: set[str] = set()
+    known_ids: set[str] = set()
+    for declaration in list_builtin_providers():
+        for model in declaration.models:
+            identifiers = {
+                model.model_id.lower(),
+                *(alias.lower() for alias in model.aliases),
+            }
+            known_ids |= identifiers
+            if model.capabilities.reasoning_content:
+                reasoning_ids |= identifiers
+    return frozenset(reasoning_ids), frozenset(known_ids)
 
 
 @lru_cache

--- a/backend/services/ai_reviewer/reviewer.py
+++ b/backend/services/ai_reviewer/reviewer.py
@@ -131,6 +131,20 @@ def _coerce_tool_call_to_dict(tc: Any) -> dict[str, Any]:
     }
 
 
+def _resolve_served_model(response: Any, current_model: str | None) -> str | None:
+    """从响应 meta 提取实际服务模型名 / Extract the winning model id.
+
+    fallback 可能切换到与角色首选不同的模型；``reasoning_content`` 等
+    模型相关判断必须基于实际 winner（与 issue_analyzer._resolve_served_model
+    保持一致）。``meta.served_by`` 形如 ``"provider/model"``，取末段作为
+    模型名；缺失或格式异常时保持原值。
+    """
+    served_by = getattr(getattr(response, "meta", None), "served_by", "")
+    if served_by and "/" in served_by:
+        return served_by.rsplit("/", 1)[-1]
+    return current_model
+
+
 def _normalize_tool_calls_inplace(messages: list[dict[str, Any]]) -> None:
     """把 messages 中所有 tool_calls 原地规范化为标准 OpenAI dict。"""
     for message in messages:
@@ -436,7 +450,7 @@ class AIReviewer:
         # 如 deepseek-v4-flash 内置 1M tokens），避免 model_context 在未提供模型名时
         # 回退 128K 兜底（曾导致日志误报 102K 上限、过早触发压缩）。
         (
-            _ctx_model_id,
+            context_model,
             context_window_tokens,
         ) = await self.api_client.resolve_role_model_context("main")
         if context_window_tokens and context_window_tokens > 0:
@@ -464,7 +478,9 @@ class AIReviewer:
             if (
                 hasattr(assistant_message, "reasoning_content")
                 and assistant_message.reasoning_content
-                and strategy_config.is_model_supports_reasoning_content("")
+                and strategy_config.is_model_supports_reasoning_content(
+                    context_model or ""
+                )
             ):
                 assistant_msg_dict["reasoning_content"] = (
                     assistant_message.reasoning_content
@@ -515,6 +531,10 @@ class AIReviewer:
                     logger.warning("event_callback failed: {}", exc)
             response = await self.api_client.call_with_retry(**call_kwargs)
             tracker.accumulate(response)
+            # fallback 可能切换到不同能力的模型，reasoning_content 等模型
+            # 相关判断必须基于实际 winner（Issue #529：此前判定传空字符串
+            # 导致思考轨迹在工具循环中恒被丢弃）
+            context_model = _resolve_served_model(response, context_model)
             reported_context_tokens = tracker.log_context_usage(
                 response,
                 context_window_tokens,
@@ -687,7 +707,7 @@ class AIReviewer:
                             "safe_context": reported_context_window,
                             "estimated_message_tokens": estimated_message_tokens,
                             "context_source": "provider",
-                            "model": "",
+                            "model": context_model or "",
                         },
                     )
                 except Exception as exc:

--- a/backend/services/ai_reviewer/reviewer.py
+++ b/backend/services/ai_reviewer/reviewer.py
@@ -474,13 +474,24 @@ class AIReviewer:
                 "content": assistant_message.content,
                 "tool_calls": [_coerce_tool_call_to_dict(tc) for tc in tool_calls],
             }
-            strategy_config = get_strategy_config()
+            # 判定优先用实际 winner 的有效能力（已含 ai_model_override
+            # 覆盖，管理员关闭某模型的 reasoning_content 时此处为 False）；
+            # 响应未携带能力信息时回退模型名判定（Issue #529）
+            served_caps = getattr(
+                getattr(response, "meta", None), "served_capabilities", None
+            )
+            if served_caps is not None:
+                supports_reasoning = served_caps.reasoning_content
+            else:
+                supports_reasoning = (
+                    get_strategy_config().is_model_supports_reasoning_content(
+                        context_model or ""
+                    )
+                )
             if (
                 hasattr(assistant_message, "reasoning_content")
                 and assistant_message.reasoning_content
-                and strategy_config.is_model_supports_reasoning_content(
-                    context_model or ""
-                )
+                and supports_reasoning
             ):
                 assistant_msg_dict["reasoning_content"] = (
                     assistant_message.reasoning_content
@@ -535,6 +546,10 @@ class AIReviewer:
             # 相关判断必须基于实际 winner（Issue #529：此前判定传空字符串
             # 导致思考轨迹在工具循环中恒被丢弃）
             context_model = _resolve_served_model(response, context_model)
+            # 压缩（含失败回退的 _clean_message_for_model）也须按实际 winner
+            # 判定 reasoning_content 去留，否则主循环保留的字段会在压缩
+            # 回退时又被剥掉
+            self.context_compressor.model = context_model or ""
             reported_context_tokens = tracker.log_context_usage(
                 response,
                 context_window_tokens,
@@ -954,9 +969,10 @@ class AIReviewer:
                 if self.enable_compression:
                     settings = get_settings()
                     (
-                        _ctx_model_id,
+                        served_model_id,
                         ctx_tokens,
                     ) = await self.api_client.resolve_role_model_context("main")
+                    self.context_compressor.model = served_model_id or ""
                     if ctx_tokens and ctx_tokens > 0:
                         safe_context = int(
                             ctx_tokens * settings.context_safety_threshold

--- a/backend/services/ai_reviewer/unified_client.py
+++ b/backend/services/ai_reviewer/unified_client.py
@@ -638,6 +638,7 @@ class UnifiedAIClient:
                 response.meta.context_window_tokens = (
                     candidate.model.context_window_tokens
                 )
+                response.meta.served_capabilities = candidate.model.capabilities
                 # 记录该 role 的成功候选，供后续调用 sticky 提升
                 self._last_successful[role] = candidate.sticky_identity
                 logger.info(
@@ -733,6 +734,9 @@ class UnifiedAIClient:
                         recovered.meta.served_by = served_by
                         recovered.meta.context_window_tokens = (
                             candidate.model.context_window_tokens
+                        )
+                        recovered.meta.served_capabilities = (
+                            candidate.model.capabilities
                         )
                         # 压缩重试成功仍属于该候选，记录 sticky
                         self._last_successful[role] = candidate.sticky_identity

--- a/backend/services/issue_analyzer.py
+++ b/backend/services/issue_analyzer.py
@@ -702,18 +702,30 @@ class IssueAnalyzer:
                 "tool_calls": tool_calls,
             }
 
-            # DeepSeek-R1 reasoning_content 支持
+            # reasoning_content 支持：优先用实际 winner 的有效能力（已含
+            # ai_model_override 覆盖），响应未携带能力信息时回退模型名判定
+            # / Prefer the winner's effective capabilities, falling back to
+            # model-name detection when the response carries no capabilities.
+            served_caps = getattr(
+                getattr(response, "meta", None), "served_capabilities", None
+            )
+            if served_caps is not None:
+                supports_reasoning = served_caps.reasoning_content
+            else:
+                strategy_config = get_strategy_config()
+                supports_reasoning = (
+                    strategy_config.is_model_supports_reasoning_content(
+                        context_model or ""
+                    )
+                )
             if (
                 hasattr(assistant_message, "reasoning_content")
                 and assistant_message.reasoning_content
+                and supports_reasoning
             ):
-                strategy_config = get_strategy_config()
-                if strategy_config.is_model_supports_reasoning_content(
-                    context_model or ""
-                ):
-                    assistant_msg_dict["reasoning_content"] = (
-                        assistant_message.reasoning_content
-                    )
+                assistant_msg_dict["reasoning_content"] = (
+                    assistant_message.reasoning_content
+                )
 
             messages.append(assistant_msg_dict)
 

--- a/tests/test_ai_reviewer_incremental_callback.py
+++ b/tests/test_ai_reviewer_incremental_callback.py
@@ -49,6 +49,9 @@ async def test_tool_loop_appends_pending_user_message_before_model_request(
         calculate_safe_context=lambda model, threshold: 100_000
     )
     reviewer.enable_compression = False
+    reviewer.context_compressor = SimpleNamespace(
+        estimate_messages_tokens=lambda msgs: 10
+    )
 
     strategy_config = SimpleNamespace(get_context_enhancement_config=dict)
     monkeypatch.setattr(

--- a/tests/test_reasoning_content_replay.py
+++ b/tests/test_reasoning_content_replay.py
@@ -1,0 +1,208 @@
+"""reasoning_content 支持判定与工具循环回传测试。
+
+Issue #529：`_append_assistant_tool_turn` 曾向
+`is_model_supports_reasoning_content("")` 传入空字符串导致判定恒为
+False，且判定函数的前缀列表未覆盖目录中声明 reasoning_content=True
+的现役模型（deepseek-v4 / glm / qwen / kimi 系列），思考轨迹在多轮
+工具链中被整体丢弃。
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.config import StrategyConfig
+from backend.services.ai_reviewer.result_parser import ReviewResultParser
+from backend.services.ai_reviewer.reviewer import AIReviewer
+from backend.services.ai_reviewer.token_tracker import TokenTracker
+
+VALID_REVIEW = """<SAKURA_REVIEW>
+<VERSION>1</VERSION>
+<SCORE>8</SCORE>
+<DECISION>approve</DECISION>
+<DECISION_REASON>
+No blocking defects were found.
+</DECISION_REASON>
+<SUMMARY>
+The incremental change is safe.
+</SUMMARY>
+<FINDINGS>
+</FINDINGS>
+</SAKURA_REVIEW>"""
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        # 内置目录中声明 reasoning_content=True 的现役模型
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
+        "glm-4.7",
+        "glm-5.2",
+        "qwen3.6-flash",
+        "kimi-k2.7-code",
+        # 大小写不敏感
+        "DeepSeek-V4-Flash",
+        # 目录未覆盖的历史/自定义模型：前缀回退仍识别
+        "deepseek-r1",
+        "deepseek-reasoner",
+        "deepseek-r1-lite",
+        "deepseek-r1-zero",
+        "deepseek-r1-0528",
+    ],
+)
+def test_model_supports_reasoning_content(model_name):
+    assert StrategyConfig().is_model_supports_reasoning_content(model_name)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "",
+        # 内置目录中未声明 reasoning_content 的模型
+        "gpt-5.6-sol",
+        "claude-fable-5",
+        "mistral-small-2603",
+        # 已弃用的非推理模型（目录外，前缀不匹配）
+        "deepseek-chat",
+        "test-model",
+    ],
+)
+def test_model_does_not_support_reasoning_content(model_name):
+    assert not StrategyConfig().is_model_supports_reasoning_content(model_name)
+
+
+class _ToolLoopFakeClient:
+    """两轮响应：第一轮带 tool_calls + reasoning_content，第二轮交付审查。"""
+
+    def __init__(self, served_by: str | None, role_model: str = "test-model"):
+        self._served_by = served_by
+        self._role_model = role_model
+        self.calls = []
+
+    async def resolve_role_model_context(self, role):
+        assert role == "main"
+        return self._role_model, 100_000
+
+    async def call_with_retry(self, **kwargs):
+        self.calls.append(kwargs)
+        if len(self.calls) == 1:
+            tool_call = SimpleNamespace(
+                id="call_1",
+                type="function",
+                function=SimpleNamespace(name="get_file_diff", arguments="{}"),
+            )
+            message = SimpleNamespace(
+                content="checking diff",
+                tool_calls=[tool_call],
+                reasoning_content="thinking about the diff",
+            )
+            choice = SimpleNamespace(message=message)
+            usage = SimpleNamespace(prompt_tokens=10, completion_tokens=20)
+            meta = SimpleNamespace(served_by=self._served_by or "")
+            return SimpleNamespace(choices=[choice], usage=usage, meta=meta)
+        message = SimpleNamespace(content=VALID_REVIEW, tool_calls=[])
+        choice = SimpleNamespace(message=message)
+        usage = SimpleNamespace(prompt_tokens=10, completion_tokens=20)
+        return SimpleNamespace(choices=[choice], usage=usage)
+
+
+class _NoopToolHandler:
+    async def handle_tool_call(self, tool_call, repo, pr):
+        return {"ok": True}
+
+
+def _build_reviewer(fake_client) -> AIReviewer:
+    reviewer = AIReviewer.__new__(AIReviewer)
+    reviewer.api_client = fake_client
+    reviewer.result_parser = ReviewResultParser()
+    reviewer.tool_handler = _NoopToolHandler()
+    reviewer.model_context_mgr = SimpleNamespace(
+        calculate_safe_context=lambda model, threshold: 100_000
+    )
+    reviewer.enable_compression = False
+    reviewer.context_compressor = SimpleNamespace(
+        estimate_messages_tokens=lambda msgs: 10
+    )
+    return reviewer
+
+
+def _patch_strategy_config(monkeypatch):
+    strategy_config = SimpleNamespace(
+        get_context_enhancement_config=dict,
+        is_model_supports_reasoning_content=StrategyConfig()
+        .is_model_supports_reasoning_content,
+    )
+    monkeypatch.setattr(
+        "backend.services.ai_reviewer.reviewer.get_strategy_config",
+        lambda: strategy_config,
+    )
+
+
+async def _run_single_tool_round(reviewer) -> list[dict]:
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "initial evidence"},
+    ]
+    await reviewer._run_tool_loop(
+        messages=messages,
+        system_prompt="system",
+        strategy="standard",
+        enabled_tools=[],
+        repo=None,
+        pr=None,
+        tracker=TokenTracker(),
+        context={},
+    )
+    return messages
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_replays_reasoning_content_for_served_model(monkeypatch):
+    """served_by 指向声明 reasoning_content 的模型时，思考轨迹必须保留。"""
+    _patch_strategy_config(monkeypatch)
+    fake_client = _ToolLoopFakeClient(served_by="deepseek/deepseek-v4-flash")
+    reviewer = _build_reviewer(fake_client)
+
+    messages = await _run_single_tool_round(reviewer)
+
+    assistant_turns = [
+        m for m in messages if m.get("role") == "assistant" and m.get("tool_calls")
+    ]
+    assert assistant_turns, "工具调用轮次的 assistant 消息必须进入历史"
+    assert assistant_turns[0]["reasoning_content"] == "thinking about the diff"
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_replays_reasoning_content_for_role_model_without_served_by(
+    monkeypatch,
+):
+    """响应缺少 served_by 时，回退到角色首选模型名判定（不再硬编码空串）。"""
+    _patch_strategy_config(monkeypatch)
+    fake_client = _ToolLoopFakeClient(
+        served_by=None,
+        role_model="deepseek-v4-flash",
+    )
+    reviewer = _build_reviewer(fake_client)
+
+    messages = await _run_single_tool_round(reviewer)
+
+    assistant_turns = [
+        m for m in messages if m.get("role") == "assistant" and m.get("tool_calls")
+    ]
+    assert assistant_turns[0]["reasoning_content"] == "thinking about the diff"
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_drops_reasoning_content_for_unsupported_model(monkeypatch):
+    """served_by 指向不支持 reasoning_content 的模型时，不回传该字段。"""
+    _patch_strategy_config(monkeypatch)
+    fake_client = _ToolLoopFakeClient(served_by="openai/gpt-5.6-sol")
+    reviewer = _build_reviewer(fake_client)
+
+    messages = await _run_single_tool_round(reviewer)
+
+    assistant_turns = [
+        m for m in messages if m.get("role") == "assistant" and m.get("tool_calls")
+    ]
+    assert "reasoning_content" not in assistant_turns[0]

--- a/tests/test_reasoning_content_replay.py
+++ b/tests/test_reasoning_content_replay.py
@@ -75,9 +75,15 @@ def test_model_does_not_support_reasoning_content(model_name):
 class _ToolLoopFakeClient:
     """两轮响应：第一轮带 tool_calls + reasoning_content，第二轮交付审查。"""
 
-    def __init__(self, served_by: str | None, role_model: str = "test-model"):
+    def __init__(
+        self,
+        served_by: str | None,
+        role_model: str = "test-model",
+        served_capabilities: SimpleNamespace | None = None,
+    ):
         self._served_by = served_by
         self._role_model = role_model
+        self._served_capabilities = served_capabilities
         self.calls = []
 
     async def resolve_role_model_context(self, role):
@@ -99,7 +105,10 @@ class _ToolLoopFakeClient:
             )
             choice = SimpleNamespace(message=message)
             usage = SimpleNamespace(prompt_tokens=10, completion_tokens=20)
-            meta = SimpleNamespace(served_by=self._served_by or "")
+            meta_kwargs = {"served_by": self._served_by or ""}
+            if self._served_capabilities is not None:
+                meta_kwargs["served_capabilities"] = self._served_capabilities
+            meta = SimpleNamespace(**meta_kwargs)
             return SimpleNamespace(choices=[choice], usage=usage, meta=meta)
         message = SimpleNamespace(content=VALID_REVIEW, tool_calls=[])
         choice = SimpleNamespace(message=message)
@@ -206,3 +215,55 @@ async def test_tool_loop_drops_reasoning_content_for_unsupported_model(monkeypat
         m for m in messages if m.get("role") == "assistant" and m.get("tool_calls")
     ]
     assert "reasoning_content" not in assistant_turns[0]
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_prefers_served_capabilities_over_model_name(monkeypatch):
+    """winner 有效能力（含 ai_model_override 覆盖）优先于模型名判定。
+
+    管理员为 deepseek-v4-flash 关闭 reasoning_content 后，即使模型名判定
+    为支持，也不得回传该字段。
+    """
+    _patch_strategy_config(monkeypatch)
+    fake_client = _ToolLoopFakeClient(
+        served_by="deepseek/deepseek-v4-flash",
+        served_capabilities=SimpleNamespace(reasoning_content=False),
+    )
+    reviewer = _build_reviewer(fake_client)
+
+    messages = await _run_single_tool_round(reviewer)
+
+    assistant_turns = [
+        m for m in messages if m.get("role") == "assistant" and m.get("tool_calls")
+    ]
+    assert "reasoning_content" not in assistant_turns[0]
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_uses_served_capabilities_for_custom_model(monkeypatch):
+    """winner 能力声明 reasoning_content=True 时，目录外自定义模型也回传。"""
+    _patch_strategy_config(monkeypatch)
+    fake_client = _ToolLoopFakeClient(
+        served_by="custom/my-private-model",
+        served_capabilities=SimpleNamespace(reasoning_content=True),
+    )
+    reviewer = _build_reviewer(fake_client)
+
+    messages = await _run_single_tool_round(reviewer)
+
+    assistant_turns = [
+        m for m in messages if m.get("role") == "assistant" and m.get("tool_calls")
+    ]
+    assert assistant_turns[0]["reasoning_content"] == "thinking about the diff"
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_syncs_served_model_to_context_compressor(monkeypatch):
+    """实际 winner 模型名须同步给压缩器，避免压缩回退清理误剥保留字段。"""
+    _patch_strategy_config(monkeypatch)
+    fake_client = _ToolLoopFakeClient(served_by="deepseek/deepseek-v4-flash")
+    reviewer = _build_reviewer(fake_client)
+
+    await _run_single_tool_round(reviewer)
+
+    assert reviewer.context_compressor.model == "deepseek-v4-flash"

--- a/tests/test_unified_client_compression.py
+++ b/tests/test_unified_client_compression.py
@@ -30,6 +30,7 @@ from backend.core.ai_protocol.models import (
     UnifiedUsage,
 )
 from backend.core.ai_protocol.registry import resolve_endpoint
+from backend.core.config import StrategyConfig
 from backend.core.model_context import get_model_context_manager
 from backend.services.ai_reviewer.compression.unified_compressor import (
     UnifiedContextCompressor,
@@ -760,7 +761,13 @@ def _reviewer_under_test(monkeypatch, *, enable_compression, observer=None):
     reviewer.compression_threshold = 0.85
     reviewer.context_compressor = _FakeCompressor()
 
-    strategy_config = SimpleNamespace(get_context_enhancement_config=dict)
+    strategy_config = SimpleNamespace(
+        get_context_enhancement_config=dict,
+        # 工具循环保留 reasoning_content 前需要模型能力判定（Issue #529）
+        is_model_supports_reasoning_content=(
+            StrategyConfig().is_model_supports_reasoning_content
+        ),
+    )
     monkeypatch.setattr(
         "backend.services.ai_reviewer.reviewer.get_strategy_config",
         lambda: strategy_config,


### PR DESCRIPTION
- Update `is_model_supports_reasoning_content` to check capabilities declared in the builtin model registry, falling back to prefix matching for legacy/custom DeepSeek-R1 models.
- Extract the actual served model from API response metadata inside `AIReviewer` to handle fallbacks correctly.
- Fix a bug where passing an empty string to `is_model_supports_reasoning_content` caused reasoning content to be discarded in `AIReviewer` (fixes #529).

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**  
本次 PR 解决后端在推理内容（reasoning content）上的支持缺失，改为通过模型的 builtin 声明及实际提供的模型能力进行评估，并补充完整单元测试，防止回归。

**主要改动列表**  
- **backend/core/ai_protocol/models.py** (+7)  
  - 新增 `builtin_declarations` 与 `served_capabilities` 处理，暴露推理内容能力。  
- **backend/services/ai_reviewer/reviewer.py** (+21 / -5)  
  - 使用 winner‑served capabilities 判断是否启用推理内容；修正调用参数以获取模型返回的推理信息。  
- **backend/services/ai_reviewer/unified_client.py** (+4)  
  - 增加对模型能力的压缩/解压逻辑，确保统一客户端正确传递推理内容标识。  
- **backend/services/issue_analyzer.py** (+20 / -8)  
  - 调整问题分析流程，兼容推理内容的回放与评估。  
- **tests/**  
  - `test_ai_reviewer_incremental_callback.py` (+3)  
  - `test_reasoning_content_replay.py` (+63 / -2)  
  - `test_unified_client_compression.py` (+8 / -1)  
  - 新增/扩展单元测试，覆盖推理内容开启、模型返回、回放及统一客户端压缩等场景。

**影响范围**  
- **功能**：修复推理内容不可用的 bug，提升 AI Reviewer 的准确性与可配置性。  
- **代码**：涉及模型声明、审阅服务、问题分析及统一客户端的核心逻辑改动。  
- **测试**：新增 74 行测试，显著提升回归防护。  
- **部署**：无需额外配置变更，确保模型服务提供相应能力即可生效。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/core/ai_protocol/models.py"]
    N2["backend/services/ai_reviewer/reviewer.py"]
    N3["backend/services/ai_reviewer/unified_client.py"]
    N4["tests/test_ai_reviewer_incremental_callback.py"]
    N5["tests/test_reasoning_content_replay.py"]
    N6["tests/test_unified_client_compression.py"]
    N7["backend/core/config.py"]
    N8["backend/services/issue_analyzer.py"]
    N2 --> N7
    N3 --> N1
    N4 --> N2
    N5 --> N7
    N5 --> N2
    N6 --> N1
    N6 --> N3
```

<!-- sakura-ai-depgraph-end -->