### PR TITLE
fix(ci): remove json wrapping from docker manifest digest inspection

### DIFF
--- a/.github/workflows/sandbox-publish.yml
+++ b/.github/workflows/sandbox-publish.yml
@@ -166,14 +166,18 @@ jobs:
           set -euo pipefail
           sandboxd_digest=$(docker buildx imagetools inspect \
             "${SANDBOXD_REPOSITORY}:${{ steps.tags.outputs.immutable }}" \
-            --format '{{json .Manifest.Digest}}')
+            --format '{{.Manifest.Digest}}')
           runner_digest=$(docker buildx imagetools inspect \
             "${RUNNER_REPOSITORY}:${{ steps.tags.outputs.immutable }}" \
-            --format '{{json .Manifest.Digest}}')
-          [[ "$sandboxd_digest" =~ ^"sha256:[0-9a-f]{64}"$ ]] || exit 1
-          [[ "$runner_digest" =~ ^"sha256:[0-9a-f]{64}"$ ]] || exit 1
-          sandboxd_digest=${sandboxd_digest//\"/}
-          runner_digest=${runner_digest//\"/}
+            --format '{{.Manifest.Digest}}')
+          [[ "$sandboxd_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "sandboxd manifest inspection did not return a valid digest" >&2
+            exit 1
+          }
+          [[ "$runner_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "runner manifest inspection did not return a valid digest" >&2
+            exit 1
+          }
           echo "sandboxd_digest=$sandboxd_digest" >> "$GITHUB_OUTPUT"
           echo "runner_digest=$runner_digest" >> "$GITHUB_OUTPUT"
           {

--- a/tests/test_agent_sandbox_deployment.py
+++ b/tests/test_agent_sandbox_deployment.py
@@ -364,3 +364,78 @@ def test_sandbox_workflow_builds_both_images_and_has_immutable_output():
     assert "sudo --preserve-env=PATH" not in quality
     assert "-v /var/run/docker.sock:/var/run/docker.sock" not in quality
     assert "unexpectedly skipped" in quality
+
+
+def test_sandbox_publish_digest_inspection_executes_unquoted_manifest_contract(
+    tmp_path: Path,
+):
+    """Execute the publish step with a Docker-format-compatible fake CLI."""
+
+    bash = shutil.which("bash")
+    if bash is None or os.name != "posix":
+        pytest.skip("the workflow shell contract requires a POSIX bash")
+
+    publish = yaml.safe_load(
+        (ROOT / ".github/workflows/sandbox-publish.yml").read_text(encoding="utf-8")
+    )
+    inspect_step = next(
+        step
+        for step in publish["jobs"]["publish"]["steps"]
+        if step.get("id") == "inspect"
+    )
+    script = inspect_step["run"].replace(
+        "${{ steps.tags.outputs.immutable }}", "test-tag"
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+format=''
+while (($#)); do
+    if [[ "$1" == "--format" ]]; then
+        format="$2"
+        shift 2
+    else
+        shift
+    fi
+done
+digest=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+case "$format" in
+    *'{{json .Manifest.Digest}}'*) printf '"sha256:%s"\\n' "$digest" ;;
+    *'{{.Manifest.Digest}}'*) printf 'sha256:%s\\n' "$digest" ;;
+    *) exit 2 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    fake_docker.chmod(0o755)
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{environment['PATH']}",
+            "SANDBOXD_REPOSITORY": "ghcr.io/example/sandboxd",
+            "RUNNER_REPOSITORY": "ghcr.io/example/runner",
+            "GITHUB_OUTPUT": str(tmp_path / "github-output"),
+            "GITHUB_STEP_SUMMARY": str(tmp_path / "github-summary"),
+        }
+    )
+    result = subprocess.run(
+        [bash, "-c", script],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    github_output = (tmp_path / "github-output").read_text(encoding="utf-8")
+    assert "sandboxd_digest=sha256:" in github_output
+    assert "runner_digest=sha256:" in github_output
+    digest_record = (tmp_path / "agent-sandbox-digests.txt").read_text(
+        encoding="utf-8"
+    )
+    assert digest_record.count("@sha256:" + "a" * 64) == 2


### PR DESCRIPTION
Use the raw template format for `--format` instead of `{{json .Manifest.Digest}}` when inspecting image manifests. This eliminates the need to manually strip quotes from the output and simplifies the digest validation regex. Improved error messages are now printed to stderr if the digest format is invalid. Added a corresponding contract test to verify the workflow step with a mocked Docker CLI.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
修复 CI 流程中 Docker manifest digest 检查的错误，移除了多余的 JSON 包装逻辑。

**主要改动**
1. **CI 修复**：修改 `.github/workflows/sandbox-publish.yml`，调整命令以直接获取 digest 信息，不再进行 JSON 包装。
2. **测试补充**：在 `tests/test_agent_sandbox_deployment.py` 中新增测试用例，验证相关部署逻辑。

**影响范围**
- CI/CD 工作流
- Agent Sandbox 部署测试

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["tests/test_agent_sandbox_deployment.py"]
```

<!-- sakura-ai-depgraph-end -->