### PR TITLE
Feature/issue

### DIFF
--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -1709,36 +1709,41 @@ async def handle_issue_event(payload: dict[str, Any]) -> JSONResponse:
                             body=issue_body,
                             state="open",
                         )
-                        # 同步数据库中的 issue_state
-                        try:
-                            from sqlalchemy import update as sql_update
-
-                            from backend.models.database import (
-                                IssueAnalysis as _IA,
-                            )
-                            from backend.models.database import (
-                                async_session as _as,
-                            )
-
-                            _repo_full = f"{repo_owner}/{repo_name}"
-                            async with _as() as _session:
-                                await _session.execute(
-                                    sql_update(_IA)
-                                    .where(
-                                        _IA.repo_name == _repo_full,
-                                        _IA.issue_number == issue_number,
-                                    )
-                                    .values(issue_state="open")
-                                )
-                                await _session.commit()
-                        except Exception as _e:
-                            logger.warning(
-                                f"同步 Issue reopened 状态到数据库失败: {_e}"
-                            )
                 else:
                     logger.debug("跳过 Pull Request 的 Issue 向量同步")
             except Exception as e:
                 logger.warning(f"语义 Issue 向量同步失败: {e}")
+
+        # reopened 事件：数据库生命周期恢复独立于语义向量开关。
+        if action == "reopened" and not is_pull_request:
+            try:
+                from backend.services.issue_service import issue_service
+
+                async with get_async_session() as session:
+                    reopen_result = await issue_service.mark_issue_reopened(
+                        repo_owner,
+                        repo_name,
+                        issue_number,
+                        session,
+                    )
+                logger.info(
+                    "Issue reopened 状态已同步 {}#{}, 恢复 {} 条分析记录",
+                    f"{repo_owner}/{repo_name}",
+                    issue_number,
+                    reopen_result.get("state_updated", 0),
+                )
+            except Exception as e:
+                logger.warning(f"同步 Issue reopened 状态到数据库失败: {e}")
+
+            # 让已恢复为 open 的 Issue 及时重新进入候选池。
+            try:
+                from backend.services.agent_team.candidate_service import (
+                    AgentTeamCandidateService,
+                )
+
+                AgentTeamCandidateService().invalidate_cache()
+            except Exception:
+                pass
 
         # closed 事件：向量同步 + 数据库分析状态/issue_state 更新
         if action == "closed":

--- a/backend/api/webhook.py
+++ b/backend/api/webhook.py
@@ -1,6 +1,7 @@
 """GitHub Webhook API端点"""
 
 import asyncio
+import inspect
 import re
 from typing import Any
 
@@ -1567,6 +1568,35 @@ async def handle_revoke_command(payload: dict[str, Any]) -> JSONResponse:
         )
 
 
+async def _cancel_issue_analysis_task(issue_info: dict[str, Any]) -> bool:
+    """Cancel active analysis for one Issue before lifecycle side effects."""
+    repo_full_name = str(issue_info.get("repo_full_name") or "").strip()
+    if not repo_full_name:
+        repo_owner = str(issue_info.get("repo_owner") or "").strip()
+        repo_name = str(issue_info.get("repo_name") or "").strip()
+        repo_full_name = f"{repo_owner}/{repo_name}"
+    task_key = f"{repo_full_name}#{issue_info.get('issue_number')}"
+
+    # Lazy import keeps webhook startup independent from the worker and lets the
+    # singleton cancel every in-process task for this Issue.
+    from backend.workers.issue_worker import get_issue_worker
+
+    worker = get_issue_worker()
+    if worker is None:
+        logger.debug("[webhook] Issue lifecycle event: 无 Issue worker {}", task_key)
+        return False
+
+    result = worker.cancel_task(task_key)
+    if inspect.isawaitable(result):
+        result = await result
+    cancelled = bool(result)
+    if cancelled:
+        logger.info("[webhook] Issue lifecycle event: 已取消分析任务 {}", task_key)
+    else:
+        logger.debug("[webhook] Issue lifecycle event: 无活跃分析任务 {}", task_key)
+    return cancelled
+
+
 async def handle_issue_event(payload: dict[str, Any]) -> JSONResponse:
     """处理 Issue 事件"""
     try:
@@ -1594,11 +1624,37 @@ async def handle_issue_event(payload: dict[str, Any]) -> JSONResponse:
                 content={"status": "ignored", "reason": "bot self-event"}
             )
 
+        issue_payload = payload.get("issue") or {}
+        is_pull_request = isinstance(issue_payload, dict) and (
+            issue_payload.get("pull_request") is not None
+        )
+        if action in {"closed", "deleted"} and is_pull_request:
+            logger.info(
+                "跳过 Pull Request 的 Issue 生命周期事件: {}#{} ({})",
+                issue_info.get("repo_full_name")
+                or f"{issue_info.get('repo_owner', '')}/{issue_info.get('repo_name', '')}",
+                issue_info.get("issue_number"),
+                action,
+            )
+            return JSONResponse(
+                content={
+                    "status": "ignored",
+                    "action": action,
+                    "reason": "pull request issue event",
+                }
+            )
+
+        repo_owner = issue_info["repo_owner"]
+        repo_name = issue_info["repo_name"]
+        issue_number = issue_info["issue_number"]
+
+        # A close/delete must signal the worker before any durable lifecycle
+        # update or cleanup, otherwise a stale worker can finish in the gap.
+        if action in {"closed", "deleted"}:
+            await _cancel_issue_analysis_task(issue_info)
+
         # deleted 事件：清理数据库记录和向量索引 / deleted event: clean up DB and vector index
         if action == "deleted":
-            repo_owner = issue_info["repo_owner"]
-            repo_name = issue_info["repo_name"]
-            issue_number = issue_info["issue_number"]
             logger.info(f"处理 Issue 删除事件: {repo_owner}/{repo_name}#{issue_number}")
 
             # 延迟导入避免循环依赖 / lazy import to avoid circular dependency
@@ -1625,7 +1681,7 @@ async def handle_issue_event(payload: dict[str, Any]) -> JSONResponse:
             try:
                 # 过滤 Pull Request（PR 也触发 issues 事件）
                 issue_payload = payload.get("issue", {})
-                if not issue_payload.get("pull_request"):
+                if not is_pull_request:
                     from backend.services.issue_embedding_service import (
                         IssueEmbeddingService,
                     )
@@ -1684,25 +1740,26 @@ async def handle_issue_event(payload: dict[str, Any]) -> JSONResponse:
             except Exception as e:
                 logger.warning(f"语义 Issue 向量同步失败: {e}")
 
-        # closed 事件：向量同步 + 数据库 issue_state 更新
+        # closed 事件：向量同步 + 数据库分析状态/issue_state 更新
         if action == "closed":
-            # 同步数据库中的 issue_state
+            # Only active records become cancelled; completed records retain
+            # their terminal analysis status while their GitHub state closes.
             try:
-                from sqlalchemy import update as sql_update
+                from backend.services.issue_service import issue_service
 
-                from backend.models.database import IssueAnalysis, async_session
-
-                repo_full = f"{repo_owner}/{repo_name}"
-                async with async_session() as session:
-                    await session.execute(
-                        sql_update(IssueAnalysis)
-                        .where(
-                            IssueAnalysis.repo_name == repo_full,
-                            IssueAnalysis.issue_number == issue_number,
-                        )
-                        .values(issue_state="closed")
+                async with get_async_session() as session:
+                    close_result = await issue_service.mark_issue_closed(
+                        repo_owner,
+                        repo_name,
+                        issue_number,
+                        session,
                     )
-                    await session.commit()
+                logger.info(
+                    "Issue closed 状态已同步 {}#{}, 取消 {} 条分析记录",
+                    f"{repo_owner}/{repo_name}",
+                    issue_number,
+                    close_result.get("cancelled", 0),
+                )
             except Exception as e:
                 logger.warning(f"同步 Issue closed 状态到数据库失败: {e}")
 

--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -151,6 +151,7 @@ class IssueAnalysisStatus(str, enum.Enum):
     ANALYZING = "analyzing"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 class IssueCategory(str, enum.Enum):

--- a/backend/services/activity_observability/integration_service.py
+++ b/backend/services/activity_observability/integration_service.py
@@ -767,6 +767,92 @@ class ActivityIntegrationService:
             return await self._role_snapshot_resolver(str(work_unit.purpose))
         return await self._resolve_snapshot(str(work_unit.purpose))
 
+    async def _cleanup_started_execution(
+        self,
+        started: ReviewStartResult,
+        status: str,
+        *,
+        error_message: str | None = None,
+    ) -> None:
+        """Converge a committed, not-yet-bound execution after admission fails.
+
+        ``start_or_merge_review`` commits the invocation, work unit, and lease
+        before the execution bundle is built.  Keep this fallback keyed by the
+        durable work-unit id from ``started`` rather than by an ORM relationship
+        or a newly manufactured execution object.  A merged result is owned by
+        another worker and must never be finished by this caller.
+        """
+        if started.merged:
+            return
+
+        observability = ActivityObservabilityService(db=self._db)
+        context_service = self._lease_context or ContextService(db=self._db)
+        finish_succeeded = False
+        try:
+            await observability.finish_work_unit(
+                int(started.work_unit.id),
+                status,
+                error_message=error_message,
+            )
+            finish_succeeded = True
+        except BaseException as exc:
+            logger.warning(
+                "observability admission cleanup failed to finish work unit "
+                "(invocation_id={}, work_unit_id={}, status={}): {}",
+                started.invocation_id,
+                int(started.work_unit.id),
+                status,
+                exc,
+            )
+
+        if started.lease is None:
+            return
+        try:
+            await context_service.release_lease(started.lease)
+        except StaleThreadLeaseError as exc:
+            if finish_succeeded:
+                # The terminal work unit is durable; an expired/fenced token is
+                # no longer safe to release because it may belong to a newer
+                # owner.  This is the same convergence rule as bundle.finish.
+                logger.debug(
+                    "observability admission cleanup lease already stale "
+                    "(invocation_id={}, work_unit_id={}): {}",
+                    started.invocation_id,
+                    int(started.work_unit.id),
+                    exc,
+                )
+            else:
+                logger.warning(
+                    "observability admission cleanup failed to release stale "
+                    "lease (invocation_id={}, work_unit_id={}): {}",
+                    started.invocation_id,
+                    int(started.work_unit.id),
+                    exc,
+                )
+        except BaseException as exc:
+            logger.warning(
+                "observability admission cleanup failed to release lease "
+                "(invocation_id={}, work_unit_id={}): {}",
+                started.invocation_id,
+                int(started.work_unit.id),
+                exc,
+            )
+
+    async def _await_admission_cleanup(
+        self, cleanup: Awaitable[None]
+    ) -> None:
+        """Drain cleanup even if another cancellation reaches this task."""
+        cleanup_task = asyncio.create_task(cleanup)
+        while not cleanup_task.done():
+            try:
+                await asyncio.shield(cleanup_task)
+            except asyncio.CancelledError:
+                # Admission cleanup is the last chance to release a durable
+                # lease.  Continue draining and let the caller re-raise the
+                # original admission exception afterwards.
+                continue
+        cleanup_task.result()
+
     async def start_execution(
         self,
         resource: Mapping[str, Any] | None = None,
@@ -791,13 +877,51 @@ class ActivityIntegrationService:
             task_id=task_id,
             lease_ttl=lease_ttl,
         )
-        bundle = await self.build_execution_bundle(
-            started,
-            publication_coordinator=publication_coordinator,
-            role_snapshot=role_snapshot,
-        )
-        bundle.start_lease_heartbeat()
-        return bundle
+        bundle: ObservedExecutionBundle | None = None
+        try:
+            bundle = await self.build_execution_bundle(
+                started,
+                publication_coordinator=publication_coordinator,
+                role_snapshot=role_snapshot,
+            )
+            bundle.start_lease_heartbeat()
+            return bundle
+        except BaseException as admission_exc:
+            if not started.merged:
+                status = (
+                    "cancelled"
+                    if isinstance(admission_exc, asyncio.CancelledError)
+                    else "failed"
+                )
+                error_message = (
+                    None
+                    if status == "cancelled"
+                    else str(admission_exc) or admission_exc.__class__.__name__
+                )
+                cleanup = (
+                    bundle.finish(status, error_message=error_message)
+                    if bundle is not None
+                    else self._cleanup_started_execution(
+                        started,
+                        status,
+                        error_message=error_message,
+                    )
+                )
+                try:
+                    await self._await_admission_cleanup(cleanup)
+                except BaseException as cleanup_exc:
+                    # Preserve the admission exception.  The cleanup helper
+                    # records operation failures itself; this catches only an
+                    # unexpected orchestration/task failure.
+                    logger.warning(
+                        "observability admission cleanup orchestration failed "
+                        "(invocation_id={}, work_unit_id={}, status={}): {}",
+                        started.invocation_id,
+                        int(started.work_unit.id),
+                        status,
+                        cleanup_exc,
+                    )
+            raise
 
     async def start_auxiliary_execution(
         self,

--- a/backend/services/issue_analyzer.py
+++ b/backend/services/issue_analyzer.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from loguru import logger
 
+from backend.core.ai_protocol.errors import ReviewCancelledError
 from backend.core.config import (
     get_dynamic_config,
     get_settings,
@@ -92,6 +93,11 @@ class IssueAnalyzer:
     """Issue AI 分析引擎"""
 
     REPAIR_INSTRUCTION = ISSUE_ANALYSIS_REPAIR_INSTRUCTION
+
+    @staticmethod
+    def _raise_if_cancelled(cancel_event: Any) -> None:
+        if cancel_event is not None and cancel_event.is_set():
+            raise ReviewCancelledError("Issue 分析已被取消")
 
     def __init__(self):
         settings = get_settings()
@@ -292,6 +298,8 @@ class IssueAnalyzer:
                 repo_name,
                 issue_number,
             )
+        except ReviewCancelledError:
+            raise
         except Exception as e:
             logger.warning("GitHub API 获取评论失败: {}", e)
             return None
@@ -338,12 +346,16 @@ class IssueAnalyzer:
         deadline: AITaskDeadline | None = None,
     ) -> dict[str, Any]:
         """解析最终 Issue 分析；失败时委托公共 helper 进行累积式修复。"""
+        self._raise_if_cancelled(cancel_event)
+
         # 解析前推送 final assistant turn（保留现有行为：caller 负责 final turn 推送）
         if event_callback is not None:
             try:
                 await event_callback(
                     "message", {"role": "assistant", "content": response_text}
                 )
+            except ReviewCancelledError:
+                raise
             except Exception as exc:
                 logger.warning("event_callback failed: {}", exc)
 
@@ -354,7 +366,7 @@ class IssueAnalyzer:
         except ValueError, TypeError:
             max_attempts = 3
 
-        return await run_protocol_repair_loop(
+        result = await run_protocol_repair_loop(
             parse_fn=self._parse_analysis_result,
             error_type=IssueProtocolError,
             base_messages=messages,
@@ -372,6 +384,8 @@ class IssueAnalyzer:
             cancel_event=cancel_event,
             deadline=deadline,
         )
+        self._raise_if_cancelled(cancel_event)
+        return result
 
     @staticmethod
     def _resolve_safe_context(response: Any, current_safe_context: int) -> int:
@@ -440,6 +454,8 @@ class IssueAnalyzer:
         Returns:
             分析结果字典，包含 token 和 cost 信息
         """
+        self._raise_if_cancelled(cancel_event)
+
         task_deadline = deadline or AITaskDeadline.from_timeout(
             get_settings().review_timeout_seconds
         )
@@ -489,6 +505,8 @@ class IssueAnalyzer:
                 comments = await self._fetch_issue_comments(
                     github_app, repo_owner, repo_name, issue_info.get("issue_number", 0)
                 )
+            except ReviewCancelledError:
+                raise
             except Exception as e:
                 logger.warning("获取 Issue 评论失败（不影响分析）: {}", e)
 
@@ -519,6 +537,8 @@ class IssueAnalyzer:
                         sakura_section += f"\n### 项目概述\n{sakura_md}"
                     if memory_md:
                         sakura_section += f"\n\n### 项目记忆\n{memory_md}"
+        except ReviewCancelledError:
+            raise
         except Exception as e:
             logger.warning(".sakura/ 记忆上下文注入失败（不影响分析）: {}", e)
 
@@ -546,6 +566,8 @@ class IssueAnalyzer:
             for initial_message in messages:
                 try:
                     await event_callback("message", initial_message)
+                except ReviewCancelledError:
+                    raise
                 except Exception as exc:
                     logger.warning("event_callback failed: {}", exc)
 
@@ -580,6 +602,7 @@ class IssueAnalyzer:
                 cancel_event=cancel_event,
                 deadline=task_deadline,
             )
+            self._raise_if_cancelled(cancel_event)
 
             result["prompt_tokens"] = tracker.prompt_tokens
             result["completion_tokens"] = tracker.completion_tokens
@@ -598,6 +621,7 @@ class IssueAnalyzer:
                     result=result,
                     context=invocation_context,
                 )
+            self._raise_if_cancelled(cancel_event)
 
             logger.info(
                 "Issue #{} 分析完成 ({}轮对话, tokens: {}+{})",
@@ -610,6 +634,7 @@ class IssueAnalyzer:
 
         while True:
             iteration += 1
+            self._raise_if_cancelled(cancel_event)
 
             try:
                 prompt_was_sent = task_deadline.timeout_prompt_sent
@@ -632,13 +657,18 @@ class IssueAnalyzer:
                 ):
                     try:
                         await event_callback("message", messages[-1])
+                    except ReviewCancelledError:
+                        raise
                     except Exception as exc:
                         logger.warning("event_callback failed: {}", exc)
 
                 response = await self.api_client.call_with_retry(**call_kwargs)
+            except ReviewCancelledError:
+                raise
             except Exception as e:
+                self._raise_if_cancelled(cancel_event)
                 logger.error("AI API 调用失败: {}", e, exc_info=True)
-                return {
+                api_error_result = {
                     "category": "other",
                     "priority": "medium",
                     "summary": f"AI 分析失败: {e!s}",
@@ -654,11 +684,16 @@ class IssueAnalyzer:
                     "tool_rounds": iteration,
                     "estimated_cost": 0,
                 }
+                self._raise_if_cancelled(cancel_event)
+                return api_error_result
+
+            self._raise_if_cancelled(cancel_event)
 
             # 验证响应有效性
             if not response.choices:
+                self._raise_if_cancelled(cancel_event)
                 logger.error("AI API 返回空响应")
-                return {
+                empty_response_result = {
                     "category": "other",
                     "priority": "medium",
                     "summary": "AI 分析失败：API 返回空响应",
@@ -674,6 +709,8 @@ class IssueAnalyzer:
                     "tool_rounds": iteration,
                     "estimated_cost": 0,
                 }
+                self._raise_if_cancelled(cancel_event)
+                return empty_response_result
 
             # 累积 token 使用
             tracker.accumulate(response)
@@ -733,6 +770,8 @@ class IssueAnalyzer:
             if event_callback:
                 try:
                     await event_callback("message", assistant_msg_dict)
+                except ReviewCancelledError:
+                    raise
                 except Exception as exc:
                     logger.warning("event_callback failed: {}", exc)
 
@@ -758,6 +797,7 @@ class IssueAnalyzer:
 
             # 执行工具调用
             for tool_index, tool_call in enumerate(tool_calls):
+                self._raise_if_cancelled(cancel_event)
                 if task_deadline.is_expired():
                     await append_skipped_tool_results(
                         messages,
@@ -769,11 +809,14 @@ class IssueAnalyzer:
                     if event_callback:
                         try:
                             await event_callback("tool_running", tool_call.id)
+                        except ReviewCancelledError:
+                            raise
                         except Exception as exc:
                             logger.warning("event_callback failed: {}", exc)
                     result = await self.tool_handler.handle_tool_call(
                         tool_call, repo, None
                     )
+                    self._raise_if_cancelled(cancel_event)
                     tool_msg = {
                         "role": "tool",
                         "tool_call_id": tool_call.id,
@@ -801,8 +844,12 @@ class IssueAnalyzer:
                     if event_callback:
                         try:
                             await event_callback("message", tool_msg)
+                        except ReviewCancelledError:
+                            raise
                         except Exception as exc:
                             logger.warning("event_callback failed: {}", exc)
+                except ReviewCancelledError:
+                    raise
                 except Exception as e:
                     logger.error("工具调用失败: {}", e)
                     error_tool_msg = {
@@ -814,5 +861,7 @@ class IssueAnalyzer:
                     if event_callback:
                         try:
                             await event_callback("message", error_tool_msg)
+                        except ReviewCancelledError:
+                            raise
                         except Exception as exc:
                             logger.warning("event_callback failed: {}", exc)

--- a/backend/services/issue_service.py
+++ b/backend/services/issue_service.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import math
 import threading
+from collections.abc import Callable
 from typing import Any
 
 from loguru import logger
@@ -52,6 +53,35 @@ def _repo_name_candidates(*repo_names: str | None) -> tuple[str, ...]:
         if "/" in normalized:
             candidates.add(normalized.rsplit("/", 1)[-1])
     return tuple(candidates)
+
+
+def _issue_analysis_identity(
+    repo_owner: str | None,
+    repo_name: str | None,
+    issue_number: int,
+) -> list[Any]:
+    """Build an owner-scoped identity for IssueAnalysis lifecycle updates.
+
+    Issue records exist in both the historical short ``repo_name`` spelling
+    and the newer ``owner/repo`` spelling.  The owner predicate is mandatory
+    here: a short name alone must never allow one owner's Issue to mutate
+    another owner's same-named repository.
+    """
+    owner = str(repo_owner or "").strip()
+    name = str(repo_name or "").strip()
+    if not owner or not name:
+        return []
+
+    short_name = name.rsplit("/", 1)[-1].strip()
+    if not short_name:
+        return []
+
+    repo_names = _repo_name_candidates(short_name, f"{owner}/{short_name}")
+    return [
+        IssueAnalysis.repo_name.in_(repo_names),
+        IssueAnalysis.repo_owner == owner,
+        IssueAnalysis.issue_number == issue_number,
+    ]
 
 
 class IssueService:
@@ -309,21 +339,10 @@ class IssueService:
         in one transaction so a result save cannot observe a half-applied
         close.
         """
-        repo_names = _repo_name_candidates(
-            repo_name,
-            f"{repo_owner}/{repo_name}" if repo_owner and repo_name else None,
-        )
-        if not repo_names:
+        identity = _issue_analysis_identity(repo_owner, repo_name, issue_number)
+        if not identity:
             return {"cancelled": 0, "state_updated": 0}
 
-        identity = [
-            IssueAnalysis.repo_name.in_(repo_names),
-            IssueAnalysis.issue_number == issue_number,
-        ]
-        if repo_owner:
-            # The short spelling is retained for compatibility with older
-            # rows, so owner must be part of every lifecycle predicate.
-            identity.append(IssueAnalysis.repo_owner == repo_owner)
         cancelled_result = await db.execute(
             update(IssueAnalysis)
             .where(
@@ -349,6 +368,35 @@ class IssueService:
 
         return {
             "cancelled": int(getattr(cancelled_result, "rowcount", 0) or 0),
+            "state_updated": int(getattr(state_result, "rowcount", 0) or 0),
+        }
+
+    async def mark_issue_reopened(
+        self,
+        repo_owner: str,
+        repo_name: str,
+        issue_number: int,
+        db: AsyncSession,
+    ) -> dict[str, int]:
+        """Restore the GitHub lifecycle state for one owner's Issue.
+
+        ``IssueAnalysis.status`` represents the analysis outcome and is left
+        untouched.  Only the independent GitHub lifecycle field is restored,
+        and both short and full repository spellings are matched under the
+        supplied owner.
+        """
+        identity = _issue_analysis_identity(repo_owner, repo_name, issue_number)
+        if not identity:
+            return {"state_updated": 0}
+
+        state_result = await db.execute(
+            update(IssueAnalysis)
+            .where(and_(*identity))
+            .values(issue_state="open")
+        )
+        await db.commit()
+
+        return {
             "state_updated": int(getattr(state_result, "rowcount", 0) or 0),
         }
 
@@ -465,6 +513,8 @@ class IssueService:
         issue_number: int,
         suggested_labels: list,
         db: AsyncSession,
+        *,
+        cancellation_checkpoint: Callable[[], None] | None = None,
     ) -> dict[str, Any]:
         """应用建议标签到 Issue（集成 LabelService，支持自动创建和置信度过滤）
 
@@ -479,6 +529,10 @@ class IssueService:
             应用结果字典
         """
         result = {"applied": [], "suggested": [], "created": [], "failed": []}
+
+        def checkpoint() -> None:
+            if cancellation_checkpoint is not None:
+                cancellation_checkpoint()
 
         if not suggested_labels:
             return result
@@ -497,6 +551,9 @@ class IssueService:
 
         existing_labels = await label_service.get_repo_labels(repo_owner, repo_name)
         existing_labels_lower = {k.lower(): k for k in existing_labels}
+        # A read-only label fetch may complete after cancellation was
+        # requested.  Re-check before entering the mutation loop.
+        checkpoint()
 
         for label in suggested_labels:
             label_name = label.get("name", "")
@@ -521,6 +578,10 @@ class IssueService:
                 default_info = label_service.DEFAULT_LABELS.get(
                     label_name, {"color": "0366d6", "description": ""}
                 )
+                # ``to_thread`` cannot be cancelled once GitHub has received
+                # the request.  Check immediately before each mutation so a
+                # later suggested label is never started after cancellation.
+                checkpoint()
                 success = await asyncio.to_thread(
                     self.github_app.create_label,
                     repo_owner,
@@ -541,6 +602,9 @@ class IssueService:
 
             # 根据置信度决定是否自动应用
             if confidence >= threshold:
+                # Creation above and applying the label are independent
+                # mutations; cancellation must be checked between them too.
+                checkpoint()
                 success = await asyncio.to_thread(
                     self.github_app.add_labels_to_issue,
                     repo_owner,
@@ -576,6 +640,8 @@ class IssueService:
         repo_name: str,
         issue_number: int,
         suggested_assignees: list[dict[str, Any]],
+        *,
+        cancellation_checkpoint: Callable[[], None] | None = None,
     ) -> dict[str, Any]:
         """应用建议指派人到 Issue（支持置信度过滤）
 
@@ -586,6 +652,10 @@ class IssueService:
         Returns:
             {"applied": [], "suggested": [], "failed": []}
         """
+        def checkpoint() -> None:
+            if cancellation_checkpoint is not None:
+                cancellation_checkpoint()
+
         threshold = await get_dynamic_config("issue_assignee_confidence_threshold")
         max_assign = await get_dynamic_config("issue_auto_assign_max")
         result: dict[str, Any] = {"applied": [], "suggested": [], "failed": []}
@@ -597,6 +667,10 @@ class IssueService:
         collaborators = await asyncio.to_thread(
             self.github_app.get_repo_collaborators, repo_owner, repo_name
         )
+        # Collaborator discovery is read-only; after it returns, do not begin
+        # an assignment mutation if the lifecycle cancellation arrived while
+        # the lookup was in flight.
+        checkpoint()
         if not collaborators:
             logger.warning(
                 f"Issue #{issue_number} 协作者列表为空，可能是权限不足，自动指派将降级为仅建议"
@@ -635,6 +709,9 @@ class IssueService:
 
             # 根据置信度决定是否自动指派
             if confidence >= threshold and len(result["applied"]) < max_assign:
+                # Check immediately before every add_assignees mutation in the
+                # loop, including after any previous mutation has completed.
+                checkpoint()
                 success = await asyncio.to_thread(
                     self.github_app.add_assignees_to_issue,
                     repo_owner,

--- a/backend/services/issue_service.py
+++ b/backend/services/issue_service.py
@@ -7,7 +7,7 @@ import threading
 from typing import Any
 
 from loguru import logger
-from sqlalchemy import and_, delete, desc, func, select
+from sqlalchemy import and_, delete, desc, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.core.config import (
@@ -31,6 +31,27 @@ def _apply_scope_filter(query, scope_filter):
     if scope_filter is not None:
         return query.where(scope_filter)
     return query
+
+
+def _repo_name_candidates(*repo_names: str | None) -> tuple[str, ...]:
+    """Return the short/full repository spellings used by Issue records.
+
+    Webhook payloads use the short repository name while older records and
+    related tables may use ``owner/repository``.  Keep this compatibility
+    local to the Issue lifecycle queries instead of changing the persisted
+    representation globally.
+    """
+    candidates: set[str] = set()
+    for value in repo_names:
+        if not value:
+            continue
+        normalized = str(value).strip()
+        if not normalized:
+            continue
+        candidates.add(normalized)
+        if "/" in normalized:
+            candidates.add(normalized.rsplit("/", 1)[-1])
+    return tuple(candidates)
 
 
 class IssueService:
@@ -69,24 +90,65 @@ class IssueService:
         analysis_data: dict[str, Any],
         issue_info: dict[str, Any],
         db: AsyncSession,
+        *,
+        analysis_id: int | None = None,
     ) -> IssueAnalysis | None:
-        """保存分析结果到数据库（更新已有的 PENDING 记录，而非创建新记录）"""
+        """保存分析结果到数据库（更新已有的 PENDING 记录，而非创建新记录）
 
-        # 查找已有的 PENDING/ANALYZING 记录
-        conditions = [
-            IssueAnalysis.repo_name == issue_info["repo_name"],
-            IssueAnalysis.issue_number == issue_info["issue_number"],
-            IssueAnalysis.status.in_(
-                [
-                    IssueAnalysisStatus.PENDING.value,
-                    IssueAnalysisStatus.ANALYZING.value,
-                ]
-            ),
-        ]
-        if "analysis_version" in issue_info:
-            conditions.append(
-                IssueAnalysis.analysis_version == issue_info["analysis_version"]
+        The final write is conditional on the record still being active.  A
+        close webhook can therefore win the race and mark the record
+        ``cancelled`` without a stale worker changing it back to
+        ``completed``.
+
+        ``analysis_id`` is supplied by the worker that created the row.  It is
+        intentionally preferred over an issue/version lookup because concurrent
+        analyses for one Issue must never update each other's result.
+        """
+
+        # Prefer the immutable task-bound id.  The fallback keeps direct legacy
+        # callers working, but remains owner-scoped whenever a webhook supplies
+        # the repository owner.
+        if analysis_id is not None:
+            conditions = [IssueAnalysis.id == analysis_id]
+        else:
+            repo_names = _repo_name_candidates(
+                issue_info.get("repo_name"),
+                issue_info.get("repo_full_name"),
+                (
+                    f"{issue_info.get('repo_owner', '')}/{issue_info.get('repo_name', '')}"
+                    if issue_info.get("repo_owner") and issue_info.get("repo_name")
+                    else None
+                ),
             )
+            if not repo_names:
+                return None
+            conditions = [
+                IssueAnalysis.repo_name.in_(repo_names),
+                IssueAnalysis.issue_number == issue_info["issue_number"],
+            ]
+            if issue_info.get("repo_owner"):
+                conditions.append(
+                    IssueAnalysis.repo_owner == issue_info["repo_owner"]
+                )
+            if "analysis_version" in issue_info:
+                conditions.append(
+                    IssueAnalysis.analysis_version == issue_info["analysis_version"]
+                )
+
+        conditions.extend(
+            [
+                IssueAnalysis.status.in_(
+                    [
+                        IssueAnalysisStatus.PENDING.value,
+                        IssueAnalysisStatus.ANALYZING.value,
+                    ]
+                ),
+                or_(
+                    IssueAnalysis.issue_state.is_(None),
+                    IssueAnalysis.issue_state != "closed",
+                ),
+            ]
+        )
         result = await db.execute(
             select(IssueAnalysis)
             .where(and_(*conditions))
@@ -98,31 +160,63 @@ class IssueService:
         if not record:
             return None
 
-        # 更新已有记录
-        record.category = analysis_data.get("category")
-        record.priority = analysis_data.get("priority")
-        record.summary = analysis_data.get("summary")
-        record.feasibility = analysis_data.get("feasibility")
-        record.suggested_title = analysis_data.get("suggested_title")
-        record.suggested_assignees = json.dumps(
-            analysis_data.get("suggested_assignees", []), ensure_ascii=False
+        # Update only while the selected row is still active.  This second
+        # conditional boundary is intentional: the close webhook may commit
+        # between the select above and this write.
+        update_result = await db.execute(
+            update(IssueAnalysis)
+            .where(
+                and_(
+                    IssueAnalysis.id == record.id,
+                    (
+                        IssueAnalysis.repo_owner == issue_info["repo_owner"]
+                        if issue_info.get("repo_owner")
+                        else True
+                    ),
+                    IssueAnalysis.status.in_(
+                        [
+                            IssueAnalysisStatus.PENDING.value,
+                            IssueAnalysisStatus.ANALYZING.value,
+                        ]
+                    ),
+                    or_(
+                        IssueAnalysis.issue_state.is_(None),
+                        IssueAnalysis.issue_state != "closed",
+                    ),
+                )
+            )
+            .values(
+                category=analysis_data.get("category"),
+                priority=analysis_data.get("priority"),
+                summary=analysis_data.get("summary"),
+                feasibility=analysis_data.get("feasibility"),
+                suggested_title=analysis_data.get("suggested_title"),
+                suggested_assignees=json.dumps(
+                    analysis_data.get("suggested_assignees", []), ensure_ascii=False
+                ),
+                suggested_labels=json.dumps(
+                    analysis_data.get("suggested_labels", []), ensure_ascii=False
+                ),
+                suggested_milestone=analysis_data.get("suggested_milestone"),
+                duplicate_of=analysis_data.get("duplicate_of"),
+                related_prs=json.dumps(
+                    analysis_data.get("related_prs", []), ensure_ascii=False
+                ),
+                analysis_detail=json.dumps(analysis_data, ensure_ascii=False),
+                status=IssueAnalysisStatus.COMPLETED.value,
+                prompt_tokens=analysis_data.get("prompt_tokens", 0),
+                completion_tokens=analysis_data.get("completion_tokens", 0),
+                estimated_cost=analysis_data.get("estimated_cost", 0),
+                completed_at=now_utc(),
+            )
         )
-        record.suggested_labels = json.dumps(
-            analysis_data.get("suggested_labels", []), ensure_ascii=False
-        )
-        record.suggested_milestone = analysis_data.get("suggested_milestone")
-        record.duplicate_of = analysis_data.get("duplicate_of")
-        record.related_prs = json.dumps(
-            analysis_data.get("related_prs", []), ensure_ascii=False
-        )
-        record.analysis_detail = json.dumps(analysis_data, ensure_ascii=False)
-        record.status = IssueAnalysisStatus.COMPLETED.value
-        record.prompt_tokens = analysis_data.get("prompt_tokens", 0)
-        record.completion_tokens = analysis_data.get("completion_tokens", 0)
-        record.estimated_cost = analysis_data.get("estimated_cost", 0)
-        record.completed_at = now_utc()
 
         await db.commit()
+        if getattr(update_result, "rowcount", None) == 0:
+            # The row was cancelled/closed by another transaction after the
+            # lookup.  Treat that as a normal stale-worker outcome.
+            return None
+
         await db.refresh(record)
         return record
 
@@ -130,11 +224,12 @@ class IssueService:
         self, repo_name: str, issue_number: int, db: AsyncSession
     ) -> IssueAnalysis | None:
         """获取 Issue 的最新分析记录"""
+        repo_names = _repo_name_candidates(repo_name)
         result = await db.execute(
             select(IssueAnalysis)
             .where(
                 and_(
-                    IssueAnalysis.repo_name == repo_name,
+                    IssueAnalysis.repo_name.in_(repo_names),
                     IssueAnalysis.issue_number == issue_number,
                     IssueAnalysis.status != "archived",
                 )
@@ -148,11 +243,12 @@ class IssueService:
         self, repo_name: str, issue_number: int, db: AsyncSession
     ) -> list[IssueAnalysis]:
         """获取 Issue 的所有分析版本历史"""
+        repo_names = _repo_name_candidates(repo_name)
         result = await db.execute(
             select(IssueAnalysis)
             .where(
                 and_(
-                    IssueAnalysis.repo_name == repo_name,
+                    IssueAnalysis.repo_name.in_(repo_names),
                     IssueAnalysis.issue_number == issue_number,
                 )
             )
@@ -175,8 +271,9 @@ class IssueService:
         count_query = select(func.count(IssueAnalysis.id))
 
         if repo_name:
-            query = query.where(IssueAnalysis.repo_name == repo_name)
-            count_query = count_query.where(IssueAnalysis.repo_name == repo_name)
+            repo_names = _repo_name_candidates(repo_name)
+            query = query.where(IssueAnalysis.repo_name.in_(repo_names))
+            count_query = count_query.where(IssueAnalysis.repo_name.in_(repo_names))
         if category:
             query = query.where(IssueAnalysis.category == category)
             count_query = count_query.where(IssueAnalysis.category == category)
@@ -196,6 +293,64 @@ class IssueService:
         items = result.scalars().all()
 
         return list(items), total
+
+    async def mark_issue_closed(
+        self,
+        repo_owner: str,
+        repo_name: str,
+        issue_number: int,
+        db: AsyncSession,
+    ) -> dict[str, int]:
+        """Persist a GitHub Issue close without reviving completed results.
+
+        Active analysis rows are transitioned to ``cancelled``.  Completed
+        rows retain their terminal analysis status, while every matching row
+        receives the GitHub lifecycle state ``closed``.  The two updates run
+        in one transaction so a result save cannot observe a half-applied
+        close.
+        """
+        repo_names = _repo_name_candidates(
+            repo_name,
+            f"{repo_owner}/{repo_name}" if repo_owner and repo_name else None,
+        )
+        if not repo_names:
+            return {"cancelled": 0, "state_updated": 0}
+
+        identity = [
+            IssueAnalysis.repo_name.in_(repo_names),
+            IssueAnalysis.issue_number == issue_number,
+        ]
+        if repo_owner:
+            # The short spelling is retained for compatibility with older
+            # rows, so owner must be part of every lifecycle predicate.
+            identity.append(IssueAnalysis.repo_owner == repo_owner)
+        cancelled_result = await db.execute(
+            update(IssueAnalysis)
+            .where(
+                and_(
+                    *identity,
+                    IssueAnalysis.status.in_(
+                        [
+                            IssueAnalysisStatus.PENDING.value,
+                            IssueAnalysisStatus.ANALYZING.value,
+                        ]
+                    ),
+                )
+            )
+            .values(
+                status=IssueAnalysisStatus.CANCELLED.value,
+                issue_state="closed",
+            )
+        )
+        state_result = await db.execute(
+            update(IssueAnalysis).where(and_(*identity)).values(issue_state="closed")
+        )
+        await db.commit()
+
+        return {
+            "cancelled": int(getattr(cancelled_result, "rowcount", 0) or 0),
+            "state_updated": int(getattr(state_result, "rowcount", 0) or 0),
+        }
 
     async def post_analysis_comment(
         self,
@@ -799,6 +954,7 @@ class IssueService:
 
         # Full repo name for DB queries / 数据库查询用的完整仓库名
         full_repo_name = f"{repo_owner}/{repo_name}"
+        repo_names = _repo_name_candidates(full_repo_name, repo_name)
         issue_label = f"{full_repo_name}#{issue_number}"
 
         # 1. Remove from ChromaDB vector index / 从 ChromaDB 向量索引中删除
@@ -814,7 +970,8 @@ class IssueService:
             (
                 IssueAnalysis,
                 [
-                    IssueAnalysis.repo_name == full_repo_name,
+                    IssueAnalysis.repo_name.in_(repo_names),
+                    IssueAnalysis.repo_owner == repo_owner,
                     IssueAnalysis.issue_number == issue_number,
                 ],
                 "IssueAnalysis",
@@ -822,6 +979,8 @@ class IssueService:
             (
                 PRIssueLink,
                 [
+                    # These legacy tables have no owner column; only the full
+                    # owner/name spelling is safe for destructive cleanup.
                     PRIssueLink.repo_name == full_repo_name,
                     PRIssueLink.issue_number == issue_number,
                 ],
@@ -830,6 +989,8 @@ class IssueService:
             (
                 IssueAnalysisQueue,
                 [
+                    # See PRIssueLink above: never delete another owner's
+                    # short-name queue row.
                     IssueAnalysisQueue.repo_name == full_repo_name,
                     IssueAnalysisQueue.issue_number == issue_number,
                 ],

--- a/backend/services/protocol_repair.py
+++ b/backend/services/protocol_repair.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from loguru import logger
 
+from backend.core.ai_protocol.errors import ReviewCancelledError
 from backend.services.ai_task_deadline import AITaskDeadline
 from backend.webui.sse import publish_event
 
@@ -26,6 +27,12 @@ ProtocolRepairBeforeCall = Callable[
 TIMEOUT_TOOL_ERROR = (
     "Task deadline reached; this tool call was not executed."
 )
+
+
+def _raise_if_cancelled(cancel_event: Any) -> None:
+    """Keep cancellation distinct from protocol/API failures."""
+    if cancel_event is not None and cancel_event.is_set():
+        raise ReviewCancelledError()
 
 
 def _tool_call_id(tool_call: Any) -> Any:
@@ -91,12 +98,17 @@ async def run_protocol_repair_loop(
     先本地解析 final_text（零模型调用的快路径）；失败则进入累积式修复循环，
     每轮把当轮具体协议违规注入 user 修复消息。上限内全部失败则降级。
     """
+    _raise_if_cancelled(cancel_event)
+
     # 1. 本地解析快路径
     try:
         result = parse_fn(final_text)
         if on_repaired is not None:
             await on_repaired(final_text, final_text, result)
+        _raise_if_cancelled(cancel_event)
         return result
+    except ReviewCancelledError:
+        raise
     except error_type as first_error:
         logger.warning(
             "{label} 协议解析失败，进入修复循环（上限 {n}）: {err}",
@@ -116,6 +128,7 @@ async def run_protocol_repair_loop(
     pre_call_control = before_call or pre_call
 
     for attempt in range(1, max_attempts + 1):
+        _raise_if_cancelled(cancel_event)
         instruction = repair_instruction + VIOLATION_SUFFIX.format(error=last_error)
         repair_messages = [
             *repair_messages,
@@ -170,6 +183,8 @@ async def run_protocol_repair_loop(
 
         try:
             response = await api_client.call_with_retry(**call_kwargs)
+        except ReviewCancelledError:
+            raise
         except Exception as call_error:
             logger.error(
                 "{label} 协议修复调用失败（第 {n} 轮），降级: {err}",
@@ -185,8 +200,12 @@ async def run_protocol_repair_loop(
                 log_label=log_label,
                 outcome="call_failed",
             )
-            return fallback_result_fn(call_error)
+            _raise_if_cancelled(cancel_event)
+            fallback_result = fallback_result_fn(call_error)
+            _raise_if_cancelled(cancel_event)
+            return fallback_result
 
+        _raise_if_cancelled(cancel_event)
         tracker.accumulate(response)
         current_text = response.choices[0].message.content or ""
 
@@ -201,6 +220,7 @@ async def run_protocol_repair_loop(
             result = parse_fn(current_text)
             if on_repaired is not None:
                 await on_repaired(final_text, current_text, result)
+            _raise_if_cancelled(cancel_event)
             await _publish_repair_event(
                 sse_channel,
                 attempt=attempt,
@@ -209,7 +229,10 @@ async def run_protocol_repair_loop(
                 log_label=log_label,
                 outcome="succeeded",
             )
+            _raise_if_cancelled(cancel_event)
             return result
+        except ReviewCancelledError:
+            raise
         except error_type as err:
             last_error = err
             logger.warning(
@@ -233,7 +256,10 @@ async def run_protocol_repair_loop(
         log_label=log_label,
         outcome="degraded",
     )
-    return fallback_result_fn(last_error)
+    _raise_if_cancelled(cancel_event)
+    fallback_result = fallback_result_fn(last_error)
+    _raise_if_cancelled(cancel_event)
+    return fallback_result
 
 
 async def _emit_event(
@@ -244,6 +270,8 @@ async def _emit_event(
     """best-effort 推送事件，吞掉可观测性侧异常，不影响修复主流程。"""
     try:
         await callback(event_type, data)
+    except ReviewCancelledError:
+        raise
     except Exception as exc:
         logger.warning("protocol repair event_callback failed: {}", exc)
 
@@ -267,5 +295,7 @@ async def _publish_repair_event(
     }
     try:
         await publish_event("protocol_repair_attempt", payload, channel=channel)
+    except ReviewCancelledError:
+        raise
     except Exception as exc:
         logger.warning("protocol repair SSE publish failed: {}", exc)

--- a/backend/webui/templates/components/issue_detail_fragment.html
+++ b/backend/webui/templates/components/issue_detail_fragment.html
@@ -5,8 +5,14 @@
         <span class="px-2.5 py-1 rounded-full text-xs font-medium
             {% if analysis.status == 'completed' %}bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400
             {% elif analysis.status == 'failed' %}bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400
+            {% elif analysis.status == 'cancelled' %}bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400
             {% else %}bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400{% endif %}">
-            {{ analysis.status }}
+            {% if analysis.status == 'completed' %}{{ _('issue.completed_status') }}
+            {% elif analysis.status == 'failed' %}{{ _('issue.failed_status') }}
+            {% elif analysis.status == 'cancelled' %}{{ _('issue.cancelled_status') }}
+            {% elif analysis.status == 'analyzing' %}{{ _('issue.analyzing_status') }}
+            {% elif analysis.status == 'pending' %}{{ _('issue.pending_status') }}
+            {% else %}{{ analysis.status or _('activity.unknown') }}{% endif %}
         </span>
     </div>
 

--- a/backend/webui/templates/components/issue_filters.html
+++ b/backend/webui/templates/components/issue_filters.html
@@ -25,6 +25,7 @@
             <option value="completed" {% if status == 'completed' %}selected{% endif %}>{{ _('scan.completed') }}</option>
             <option value="failed" {% if status == 'failed' %}selected{% endif %}>{{ _('queue.failed') }}</option>
             <option value="analyzing" {% if status == 'analyzing' %}selected{% endif %}>{{ _('common.processing') }}</option>
+            <option value="cancelled" {% if status == 'cancelled' %}selected{% endif %}>{{ _('issue.cancelled_status') }}</option>
             <option value="pending" {% if status == 'pending' %}selected{% endif %}>{{ _('common.pending') }}</option>
         </select>
         <button type="button" onclick="loadPage(1)"

--- a/backend/webui/templates/components/issue_list_fragment.html
+++ b/backend/webui/templates/components/issue_list_fragment.html
@@ -15,8 +15,12 @@
                 <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">{{ _('queue.failed') }}</span>
                 {% elif a.status == 'analyzing' %}
                 <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400">{{ _('common.processing') }}</span>
-                {% else %}
+                {% elif a.status == 'cancelled' %}
+                <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">{{ _('issue.cancelled_status') }}</span>
+                {% elif a.status == 'pending' %}
                 <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">{{ _('common.pending') }}</span>
+                {% else %}
+                <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">{{ a.status or _('activity.unknown') }}</span>
                 {% endif %}
             </div>
 

--- a/backend/webui/templates/issue_detail.html
+++ b/backend/webui/templates/issue_detail.html
@@ -37,16 +37,18 @@
                 <span class="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">{{ analysis.priority }}</span>
                 {% endif %}
                 {% endif %}
-                {% if analysis.status %}
                 {% if analysis.status == 'completed' %}
                 <span class="px-3 py-1 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">{{ _('issue.completed_status') }}</span>
                 {% elif analysis.status == 'failed' %}
                 <span class="px-3 py-1 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">{{ _('issue.failed_status') }}</span>
                 {% elif analysis.status == 'analyzing' %}
                 <span class="px-3 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400">{{ _('issue.analyzing_status') }}</span>
-                {% else %}
+                {% elif analysis.status == 'cancelled' %}
+                <span class="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">{{ _('issue.cancelled_status') }}</span>
+                {% elif analysis.status == 'pending' %}
                 <span class="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">{{ _('issue.pending_status') }}</span>
-                {% endif %}
+                {% else %}
+                <span class="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400">{{ analysis.status or _('activity.unknown') }}</span>
                 {% endif %}
             </div>
         </div>

--- a/backend/workers/issue_worker.py
+++ b/backend/workers/issue_worker.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import uuid
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -86,6 +87,13 @@ class IssueWorker:
         ] = {}
         self._task_executions: dict[str, dict[str, Any | None]] = {}
         self._task_execution_statuses: dict[str, dict[str, str | None]] = {}
+        # A worker task can hand a synchronous GitHub mutation to
+        # ``asyncio.to_thread``.  Cancelling the worker only cancels the await
+        # around that thread, so retain every in-flight write until its child
+        # task has really finished.
+        self._task_external_writes: dict[
+            str, dict[str, set[asyncio.Task[Any]]]
+        ] = {}
         from backend.services.activity_observability.integration_service import (
             ActivityIntegrationService,
         )
@@ -159,6 +167,121 @@ class IssueWorker:
         if executions is None:
             self._task_executions = executions = {}
         executions.setdefault(task_key, {})[task_id] = execution
+
+    def _register_external_write(
+        self, task_key: str, task_id: str, write_task: asyncio.Task[Any]
+    ) -> None:
+        writes = getattr(self, "_task_external_writes", None)
+        if writes is None:
+            self._task_external_writes = writes = {}
+        writes.setdefault(task_key, {}).setdefault(task_id, set()).add(write_task)
+
+    def _unregister_external_write(
+        self, task_key: str, task_id: str, write_task: asyncio.Task[Any]
+    ) -> None:
+        writes = getattr(self, "_task_external_writes", {}).get(task_key)
+        if writes is None:
+            return
+        task_writes = writes.get(task_id)
+        if task_writes is None:
+            return
+        task_writes.discard(write_task)
+        if not task_writes:
+            writes.pop(task_id, None)
+        if not writes:
+            getattr(self, "_task_external_writes", {}).pop(task_key, None)
+
+    def _get_external_writes(
+        self, task_key: str, task_id: str
+    ) -> tuple[asyncio.Task[Any], ...]:
+        return tuple(
+            write_task
+            for write_task in getattr(self, "_task_external_writes", {})
+            .get(task_key, {})
+            .get(task_id, set())
+            if not write_task.done()
+        )
+
+    async def _run_external_write(
+        self,
+        task_key: str,
+        task_id: str,
+        cancel_event: asyncio.Event,
+        operation: Callable[[], Awaitable[Any]],
+    ) -> Any:
+        """Run one external mutation through a cancellation-safe child task.
+
+        ``asyncio.to_thread`` cannot stop the synchronous function once its
+        thread has started.  The child task is therefore shielded from the
+        worker's cancellation, recorded while it is in flight, and drained
+        before the original ``CancelledError`` is re-raised.  The operation
+        factory is intentionally called only in the child after the last
+        cancellation check, so a write is never started after cooperative
+        cancellation has already been requested.
+        """
+        self._raise_if_cancelled(cancel_event)
+
+        async def _run() -> Any:
+            self._raise_if_cancelled(cancel_event)
+            return await operation()
+
+        write_task = asyncio.create_task(_run())
+        self._register_external_write(task_key, task_id, write_task)
+        cancellation: asyncio.CancelledError | None = None
+        result: Any = None
+        write_error: BaseException | None = None
+        try:
+            while not write_task.done():
+                try:
+                    await asyncio.shield(write_task)
+                except asyncio.CancelledError as exc:
+                    # Keep waiting even when duplicate lifecycle cancellation
+                    # injects another CancelledError into this worker task.
+                    if cancellation is None:
+                        cancellation = exc
+                except BaseException:
+                    # The child is done; retrieve its result below so its
+                    # exception is observed and not reported as unhandled.
+                    break
+
+            try:
+                result = write_task.result()
+            except BaseException as exc:
+                write_error = exc
+
+            # Cancellation of the worker takes precedence after the external
+            # write has drained.  This preserves normal task cancellation while
+            # still observing any write exception for diagnostics.
+            if cancellation is not None:
+                raise cancellation
+            if write_error is not None:
+                raise write_error
+            return result
+        finally:
+            self._unregister_external_write(task_key, task_id, write_task)
+
+    @staticmethod
+    async def _await_tasks_cancel_safe(
+        tasks: list[asyncio.Task[Any]],
+    ) -> list[Any]:
+        """Await task handles without letting caller cancellation abort drain."""
+        if not tasks:
+            return []
+        gathered = asyncio.gather(*tasks, return_exceptions=True)
+        cancellation: asyncio.CancelledError | None = None
+        while not gathered.done():
+            try:
+                await asyncio.shield(gathered)
+            except asyncio.CancelledError as exc:
+                # A cancelled webhook request must still wait for the worker
+                # it has already signalled before its lifecycle cleanup ends.
+                if cancellation is None:
+                    cancellation = exc
+
+        results = list(gathered.result())
+        if cancellation is not None:
+            raise cancellation
+        return results
 
     def _get_execution(self, task_key: str, task_id: str) -> Any | None:
         return getattr(self, "_task_executions", {}).get(task_key, {}).get(task_id)
@@ -245,11 +368,16 @@ class IssueWorker:
                 event.set()
                 changed = True
             task = task_handles.get(task_id)
-            if was_set or task is None or task is current_task:
+            # ``was_set`` only controls whether another cancellation request is
+            # needed.  A duplicate close/delete webhook must still await a task
+            # whose first cancellation is currently converging; otherwise its
+            # lifecycle cleanup can race the first caller's ``gather``.
+            if task is None or task is current_task:
                 continue
             try:
-                if not task.done() and task.cancel():
-                    changed = True
+                if not task.done():
+                    if not was_set and task.cancel():
+                        changed = True
                     pending.append(task)
                     pending_ids.append(task_id)
             except (AttributeError, RuntimeError):
@@ -257,8 +385,30 @@ class IssueWorker:
                 # event remains set and the normal worker cleanup still runs.
                 continue
 
-        if pending:
-            results = await asyncio.gather(*pending, return_exceptions=True)
+        # Include writes registered by a worker even if a task-handle mock or
+        # an admission edge case has temporarily lost the outer handle.  In
+        # the normal path the outer task awaits its writes itself, so this is
+        # an idempotent safety net.
+        pending_write_tasks: list[asyncio.Task[Any]] = []
+        for task_id in task_events:
+            pending_write_tasks.extend(self._get_external_writes(task_key, task_id))
+        pending_all: list[asyncio.Task[Any]] = []
+        seen: set[int] = set()
+        for task in (*pending, *pending_write_tasks):
+            marker = id(task)
+            if marker not in seen:
+                seen.add(marker)
+                pending_all.append(task)
+
+        drain_cancellation: asyncio.CancelledError | None = None
+        if pending_all:
+            try:
+                results = await self._await_tasks_cancel_safe(pending_all)
+            except asyncio.CancelledError as exc:
+                # Finish local registry cleanup below, then preserve the
+                # cancellation of the webhook request itself.
+                drain_cancellation = exc
+                results = []
             for result in results:
                 if isinstance(result, BaseException) and not isinstance(
                     result, asyncio.CancelledError
@@ -275,6 +425,8 @@ class IssueWorker:
                 self._unregister_task(task_key, task_id)
         if changed:
             logger.info("[cancel] 已终止 Issue 分析任务: {}", task_key)
+        if drain_cancellation is not None:
+            raise drain_cancellation
         return changed
 
     @staticmethod
@@ -644,6 +796,53 @@ class IssueWorker:
                         ),
                     )
 
+        async def _start_execution_cancel_safe(**kwargs: Any) -> Any:
+            """Shield observability admission until its execution is bound.
+
+            ``start_execution`` persists the invocation/work unit and lease
+            before it finishes constructing the returned bundle.  Cancelling
+            this worker while that await is in progress must not strand that
+            durable work unit without a handle that can finish and release it.
+            """
+            self._raise_if_cancelled(cancel_event)
+
+            admission_task = asyncio.create_task(
+                self.activity_integration.start_execution(**kwargs)
+            )
+            cancellation: asyncio.CancelledError | None = None
+            result: Any = None
+            admission_error: BaseException | None = None
+            while not admission_task.done():
+                try:
+                    await asyncio.shield(admission_task)
+                except asyncio.CancelledError as exc:
+                    if cancellation is None:
+                        cancellation = exc
+                except BaseException:
+                    # The child is complete; retrieve its exception below so
+                    # it is observed and classified by the caller.
+                    break
+
+            try:
+                result = admission_task.result()
+            except BaseException as exc:
+                admission_error = exc
+
+            if admission_error is not None:
+                if cancellation is not None:
+                    raise cancellation
+                raise admission_error
+
+            if not getattr(result, "merged", False):
+                # Bind before propagating the cancellation.  The outer
+                # process cancellation handler can then finish the exact
+                # execution and release its lease.
+                self._bind_execution(task_key, task_id, result)
+
+            if cancellation is not None:
+                raise cancellation
+            return result
+
         try:
             admission = await self.activity_integration.admit_issue(
                 issue_info,
@@ -661,7 +860,7 @@ class IssueWorker:
             )
             if resolver is not None:
                 role_snapshot = await resolver("main")
-            execution = await self.activity_integration.start_execution(
+            execution = await _start_execution_cancel_safe(
                 session_id=admission.session_id,
                 trigger_ids=[admission.trigger_id],
                 role_snapshot=role_snapshot,
@@ -676,7 +875,6 @@ class IssueWorker:
                     execution.invocation_id,
                 )
                 return task_id
-            self._bind_execution(task_key, task_id, execution)
         except Exception as observability_exc:
             # Observability admission is best-effort for legacy callers that lack
             # immutable repository identity; the core analysis still runs, but
@@ -1057,13 +1255,18 @@ class IssueWorker:
                                     body_with_marker: str,
                                     _resource_identity: dict[str, Any],
                                 ) -> Any:
-                                    return await asyncio.to_thread(
-                                        issue_service.github_app.create_issue_comment,
-                                        repo_owner,
-                                        repo_name,
-                                        issue_number,
-                                        body_with_marker,
-                                        raise_on_error=True,
+                                    return await self._run_external_write(
+                                        task_key,
+                                        task_id,
+                                        cancel_event,
+                                        lambda: asyncio.to_thread(
+                                            issue_service.github_app.create_issue_comment,
+                                            repo_owner,
+                                            repo_name,
+                                            issue_number,
+                                            body_with_marker,
+                                            raise_on_error=True,
+                                        ),
                                     )
 
                                 self._raise_if_cancelled(cancel_event)
@@ -1079,12 +1282,17 @@ class IssueWorker:
                                     await db.commit()
                         else:
                             self._raise_if_cancelled(cancel_event)
-                            success = await issue_service.post_analysis_comment(
-                                repo_owner,
-                                repo_name,
-                                issue_number,
-                                analysis_record,
-                                db,
+                            success = await self._run_external_write(
+                                task_key,
+                                task_id,
+                                cancel_event,
+                                lambda: issue_service.post_analysis_comment(
+                                    repo_owner,
+                                    repo_name,
+                                    issue_number,
+                                    analysis_record,
+                                    db,
+                                ),
                             )
                         if success:
                             logger.info(f"[{task_id}] 已发布分析评论")
@@ -1101,12 +1309,20 @@ class IssueWorker:
                         )
                         if labels_data:
                             self._raise_if_cancelled(cancel_event)
-                            result = await issue_service.apply_suggested_labels(
-                                repo_owner,
-                                repo_name,
-                                issue_number,
-                                labels_data,
-                                db,
+                            result = await self._run_external_write(
+                                task_key,
+                                task_id,
+                                cancel_event,
+                                lambda: issue_service.apply_suggested_labels(
+                                    repo_owner,
+                                    repo_name,
+                                    issue_number,
+                                    labels_data,
+                                    db,
+                                    cancellation_checkpoint=lambda: self._raise_if_cancelled(
+                                        cancel_event
+                                    ),
+                                ),
                             )
                             if result.get("applied"):
                                 logger.info(
@@ -1137,11 +1353,19 @@ class IssueWorker:
                             if assignees_data:
                                 self._raise_if_cancelled(cancel_event)
                                 assign_result = (
-                                    await issue_service.apply_suggested_assignees(
-                                        repo_owner,
-                                        repo_name,
-                                        issue_number,
-                                        assignees_data,
+                                    await self._run_external_write(
+                                        task_key,
+                                        task_id,
+                                        cancel_event,
+                                        lambda: issue_service.apply_suggested_assignees(
+                                            repo_owner,
+                                            repo_name,
+                                            issue_number,
+                                            assignees_data,
+                                            cancellation_checkpoint=lambda: self._raise_if_cancelled(
+                                                cancel_event
+                                            ),
+                                        ),
                                     )
                                 )
                                 if assign_result.get("applied"):
@@ -1172,12 +1396,17 @@ class IssueWorker:
                             original_title = issue_info.get("title", "")
                             if suggested_title and suggested_title != original_title:
                                 self._raise_if_cancelled(cancel_event)
-                                success = await asyncio.to_thread(
-                                    self.github_app.update_issue_title,
-                                    repo_owner,
-                                    repo_name,
-                                    issue_number,
-                                    suggested_title,
+                                success = await self._run_external_write(
+                                    task_key,
+                                    task_id,
+                                    cancel_event,
+                                    lambda: asyncio.to_thread(
+                                        self.github_app.update_issue_title,
+                                        repo_owner,
+                                        repo_name,
+                                        issue_number,
+                                        suggested_title,
+                                    ),
                                 )
                                 if success:
                                     logger.info(

--- a/backend/workers/issue_worker.py
+++ b/backend/workers/issue_worker.py
@@ -7,8 +7,9 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from loguru import logger
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, or_, select, update
 
+from backend.core.ai_protocol.errors import ReviewCancelledError
 from backend.core.config import (
     get_dynamic_config,
     get_sakura_memory_config,
@@ -67,11 +68,399 @@ class IssueWorker:
         self.analyzer = IssueAnalyzer()
         self.github_app = GitHubAppClient()
         self._background_tasks: set[asyncio.Task] = set()
+        # Cancellation signals are scoped by issue, but each running task owns
+        # its event so a later task can never inherit an already-set signal.
+        self._cancel_events: dict[str, dict[str, asyncio.Event]] = {}
+        # Keep task handles beside the event registry.  An Event alone cannot
+        # wake a task blocked in ``Semaphore.acquire()``; the handle lets the
+        # webhook interrupt and await that task before deleting/closing an
+        # Issue.
+        self._task_handles: dict[
+            str, dict[str, asyncio.Task[Any] | None]
+        ] = {}
+        # Each task owns exactly one analysis row.  Store the immutable row
+        # identity here so cancellation/failure cleanup never selects a newer
+        # sibling run for the same Issue.
+        self._task_analysis_records: dict[
+            str, dict[str, tuple[int, int | None]]
+        ] = {}
+        self._task_executions: dict[str, dict[str, Any | None]] = {}
+        self._task_execution_statuses: dict[str, dict[str, str | None]] = {}
         from backend.services.activity_observability.integration_service import (
             ActivityIntegrationService,
         )
 
         self.activity_integration = ActivityIntegrationService()
+
+    @staticmethod
+    def _make_task_key(issue_info: dict[str, Any]) -> str:
+        """Return the shared cancellation key for an Issue."""
+        repo_full_name = issue_info.get("repo_full_name") or (
+            f"{issue_info.get('repo_owner', '')}/{issue_info.get('repo_name', '')}"
+        )
+        return f"{repo_full_name}#{issue_info.get('issue_number', 0)}"
+
+    def _register_task(
+        self,
+        task_key: str,
+        task_id: str,
+        event: asyncio.Event | None = None,
+    ) -> asyncio.Event:
+        """Register one task before it is scheduled and return its signal."""
+        if not hasattr(self, "_cancel_events"):
+            self._cancel_events = {}
+        task_events = self._cancel_events.setdefault(task_key, {})
+        registered = event or asyncio.Event()
+        task_events[task_id] = registered
+        if not hasattr(self, "_task_handles"):
+            self._task_handles = {}
+        self._task_handles.setdefault(task_key, {})[task_id] = None
+        if not hasattr(self, "_task_analysis_records"):
+            self._task_analysis_records = {}
+        self._task_analysis_records.setdefault(task_key, {})
+        if not hasattr(self, "_task_executions"):
+            self._task_executions = {}
+        self._task_executions.setdefault(task_key, {})[task_id] = None
+        if not hasattr(self, "_task_execution_statuses"):
+            self._task_execution_statuses = {}
+        self._task_execution_statuses.setdefault(task_key, {})[task_id] = None
+        return registered
+
+    def _bind_task_handle(
+        self, task_key: str, task_id: str, task: asyncio.Task[Any]
+    ) -> None:
+        """Bind the scheduled task after its cancellation entry is created."""
+        handles = getattr(self, "_task_handles", None)
+        if handles is None:
+            self._task_handles = handles = {}
+        handles.setdefault(task_key, {})[task_id] = task
+
+        # A cancellation can be requested by a test double or an unusual task
+        # factory between registration and this binding.  Preserve that
+        # request instead of allowing the task to start after it was cancelled.
+        event = getattr(self, "_cancel_events", {}).get(task_key, {}).get(task_id)
+        if event is not None and event.is_set() and task is not asyncio.current_task():
+            task.cancel()
+
+    def _bind_analysis_record(
+        self, task_key: str, task_id: str, record: IssueAnalysis
+    ) -> None:
+        """Associate a worker task with its immutable analysis id/version."""
+        records = getattr(self, "_task_analysis_records", None)
+        if records is None:
+            self._task_analysis_records = records = {}
+        records.setdefault(task_key, {})[task_id] = (
+            record.id,
+            getattr(record, "analysis_version", None),
+        )
+
+    def _bind_execution(self, task_key: str, task_id: str, execution: Any) -> None:
+        executions = getattr(self, "_task_executions", None)
+        if executions is None:
+            self._task_executions = executions = {}
+        executions.setdefault(task_key, {})[task_id] = execution
+
+    def _get_execution(self, task_key: str, task_id: str) -> Any | None:
+        return getattr(self, "_task_executions", {}).get(task_key, {}).get(task_id)
+
+    def _get_execution_status(self, task_key: str, task_id: str) -> str | None:
+        return (
+            getattr(self, "_task_execution_statuses", {})
+            .get(task_key, {})
+            .get(task_id)
+        )
+
+    def _set_execution_status(
+        self, task_key: str, task_id: str, status: str
+    ) -> None:
+        statuses = getattr(self, "_task_execution_statuses", None)
+        if statuses is None:
+            self._task_execution_statuses = statuses = {}
+        statuses.setdefault(task_key, {})[task_id] = status
+
+    def _get_analysis_record_identity(
+        self, task_key: str, task_id: str
+    ) -> tuple[int, int | None] | None:
+        return (
+            getattr(self, "_task_analysis_records", {})
+            .get(task_key, {})
+            .get(task_id)
+        )
+
+    def _unregister_task(self, task_key: str, task_id: str) -> None:
+        """Remove only this task's signal; keep concurrent siblings intact."""
+        task_events = getattr(self, "_cancel_events", {}).get(task_key)
+        if task_events is not None:
+            task_events.pop(task_id, None)
+            if not task_events:
+                self._cancel_events.pop(task_key, None)
+
+        handles = getattr(self, "_task_handles", {}).get(task_key)
+        if handles is not None:
+            handles.pop(task_id, None)
+            if not handles:
+                self._task_handles.pop(task_key, None)
+
+        records = getattr(self, "_task_analysis_records", {}).get(task_key)
+        if records is not None:
+            identity = records.pop(task_id, None)
+            if identity is not None:
+                getattr(self, "_cancelled_analysis_notifications", set()).discard(
+                    identity[0]
+                )
+            if not records:
+                self._task_analysis_records.pop(task_key, None)
+
+        executions = getattr(self, "_task_executions", {}).get(task_key)
+        if executions is not None:
+            executions.pop(task_id, None)
+            if not executions:
+                self._task_executions.pop(task_key, None)
+
+        statuses = getattr(self, "_task_execution_statuses", {}).get(task_key)
+        if statuses is not None:
+            statuses.pop(task_id, None)
+            if not statuses:
+                self._task_execution_statuses.pop(task_key, None)
+
+    async def cancel_task(self, task_key: str) -> bool:
+        """Cancel and await every active task for one Issue.
+
+        Setting the event is still important for cooperative cancellation, but
+        it does not wake a task suspended in ``Semaphore.acquire``.  Cancel the
+        registered task handles as well and await their completion so lifecycle
+        webhooks can safely delete/close the Issue after worker cleanup.
+        """
+        task_events = getattr(self, "_cancel_events", {}).get(task_key, {})
+        if not task_events:
+            return False
+        task_handles = getattr(self, "_task_handles", {}).get(task_key, {})
+        changed = False
+        pending: list[asyncio.Task[Any]] = []
+        pending_ids: list[str] = []
+        current_task = asyncio.current_task()
+        for task_id, event in list(task_events.items()):
+            was_set = event.is_set()
+            if not was_set:
+                event.set()
+                changed = True
+            task = task_handles.get(task_id)
+            if was_set or task is None or task is current_task:
+                continue
+            try:
+                if not task.done() and task.cancel():
+                    changed = True
+                    pending.append(task)
+                    pending_ids.append(task_id)
+            except (AttributeError, RuntimeError):
+                # A synthetic test/task factory may expose a stale handle.  The
+                # event remains set and the normal worker cleanup still runs.
+                continue
+
+        if pending:
+            results = await asyncio.gather(*pending, return_exceptions=True)
+            for result in results:
+                if isinstance(result, BaseException) and not isinstance(
+                    result, asyncio.CancelledError
+                ):
+                    logger.warning(
+                        "[cancel] Issue 任务终止时出现异常 {}: {}",
+                        task_key,
+                        result,
+                    )
+            # A task cancelled before its coroutine first runs never reaches
+            # ``process_issue_analysis``'s finally block.  Remove those stale
+            # pre-registrations explicitly after the handle has been awaited.
+            for task_id in pending_ids:
+                self._unregister_task(task_key, task_id)
+        if changed:
+            logger.info("[cancel] 已终止 Issue 分析任务: {}", task_key)
+        return changed
+
+    @staticmethod
+    def _raise_if_cancelled(cancel_event: asyncio.Event | None) -> None:
+        if cancel_event is not None and cancel_event.is_set():
+            raise ReviewCancelledError("Issue 分析已被取消")
+
+    async def _mark_active_analysis_cancelled(
+        self,
+        db,
+        *,
+        analysis_id: int | None,
+        reason: str,
+    ) -> tuple[IssueAnalysis | None, str | None]:
+        """Converge this task's exact analysis and return its terminal status.
+
+        A worker may have siblings analyzing the same Issue concurrently.  The
+        task-bound primary key is therefore mandatory; selecting by issue and
+        ordering by ``created_at`` can cancel or overwrite the wrong sibling.
+
+        The second tuple item is the persisted status after the race.  It lets
+        callers distinguish a real ``active -> cancelled`` transition (or a
+        close/delete that already committed ``cancelled``) from a completed or
+        failed row, without publishing a misleading cancelled event.
+        """
+        if analysis_id is None:
+            return None, None
+
+        result = await db.execute(
+            select(IssueAnalysis).where(IssueAnalysis.id == analysis_id)
+        )
+        record = result.scalar_one_or_none()
+        if record is None:
+            return None, None
+
+        active_statuses = {
+            IssueAnalysisStatus.PENDING.value,
+            IssueAnalysisStatus.ANALYZING.value,
+        }
+        current_status = getattr(record, "status", None)
+        if current_status not in active_statuses:
+            # An already-cancelled row is a valid lifecycle cancellation that
+            # the worker still needs to recognize, while completed/failed rows
+            # must retain their terminal observability status.
+            return record, current_status
+
+        update_result = await db.execute(
+            update(IssueAnalysis)
+            .where(
+                and_(
+                    IssueAnalysis.id == analysis_id,
+                    IssueAnalysis.status.in_(active_statuses),
+                )
+            )
+            .values(
+                status=IssueAnalysisStatus.CANCELLED.value,
+                error_message=reason,
+            )
+        )
+        await db.commit()
+
+        rowcount = getattr(update_result, "rowcount", None)
+        if rowcount is None or rowcount > 0:
+            # Keep lightweight test doubles and the identity map in sync with
+            # the conditional UPDATE without issuing a second SELECT.
+            record.status = IssueAnalysisStatus.CANCELLED.value
+            record.error_message = reason
+            await self._log_activity(
+                record.id,
+                "cancelled",
+                {"message": reason},
+            )
+            return record, IssueAnalysisStatus.CANCELLED.value
+        elif getattr(record, "status", None) != IssueAnalysisStatus.CANCELLED.value:
+            # Another lifecycle transaction won the race.  Read the exact row
+            # only; a missing row means the Issue was deleted.
+            current_result = await db.execute(
+                select(IssueAnalysis).where(IssueAnalysis.id == analysis_id)
+            )
+            record = current_result.scalar_one_or_none()
+            if record is None:
+                return None, None
+
+        return record, getattr(record, "status", None)
+
+    async def _converge_cancelled_analysis(
+        self,
+        db,
+        *,
+        analysis_id: int | None,
+        issue_info: dict[str, Any],
+        reason: str,
+    ) -> tuple[IssueAnalysis | None, str | None]:
+        """Persist cancellation and publish the matching Issue status event."""
+        record, status = await self._mark_active_analysis_cancelled(
+            db,
+            analysis_id=analysis_id,
+            reason=reason,
+        )
+        if status != IssueAnalysisStatus.CANCELLED.value:
+            return record, status
+
+        if record is not None:
+            notified = getattr(self, "_cancelled_analysis_notifications", None)
+            if notified is None:
+                self._cancelled_analysis_notifications = notified = set()
+            already_notified = analysis_id in notified
+            if not already_notified:
+                # Set before the await so duplicate cancellation paths cannot
+                # emit two SSE events for the same analysis row.
+                notified.add(analysis_id)
+            try:
+                if not already_notified:
+                    from backend.webui.sse import publish_event
+
+                    await publish_event(
+                        "issue:status_changed",
+                        {
+                            "issue_number": issue_info.get("issue_number"),
+                            "repo_name": issue_info.get("repo_name"),
+                            "status": IssueAnalysisStatus.CANCELLED.value,
+                        },
+                    )
+            except Exception as sse_exc:
+                logger.debug(
+                    "[{}] 发布取消 SSE 事件失败: {}",
+                    issue_info.get("task_id", "unknown"),
+                    sse_exc,
+                )
+        return record, status
+
+    async def _mark_analysis_failed(
+        self,
+        db,
+        *,
+        analysis_id: int | None,
+        reason: str,
+    ) -> IssueAnalysis | None:
+        """Conditionally mark this task's exact analysis row as failed."""
+        if analysis_id is None:
+            return None
+
+        result = await db.execute(
+            select(IssueAnalysis).where(IssueAnalysis.id == analysis_id)
+        )
+        record = result.scalar_one_or_none()
+        if record is None:
+            return None
+
+        update_result = await db.execute(
+            update(IssueAnalysis)
+            .where(
+                and_(
+                    IssueAnalysis.id == analysis_id,
+                    IssueAnalysis.status.in_(
+                        [
+                            IssueAnalysisStatus.PENDING.value,
+                            IssueAnalysisStatus.ANALYZING.value,
+                        ]
+                    ),
+                    or_(
+                        IssueAnalysis.issue_state.is_(None),
+                        IssueAnalysis.issue_state != "closed",
+                    ),
+                )
+            )
+            .values(
+                status=IssueAnalysisStatus.FAILED.value,
+                error_message=reason,
+            )
+        )
+        await db.commit()
+
+        rowcount = getattr(update_result, "rowcount", None)
+        if rowcount is None or rowcount > 0:
+            record.status = IssueAnalysisStatus.FAILED.value
+            record.error_message = reason
+            return record
+
+        # A close/delete/cancel may have won between the exact read and the
+        # conditional update.  Return the exact current row for classification;
+        # never fall back to a newer sibling analysis.
+        current_result = await db.execute(
+            select(IssueAnalysis).where(IssueAnalysis.id == analysis_id)
+        )
+        return current_result.scalar_one_or_none()
 
     @staticmethod
     async def _log_activity(
@@ -93,6 +482,92 @@ class IssueWorker:
         issue_info: dict[str, Any],
         *,
         deadline: AITaskDeadline | None = None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> str:
+        """Register and run one Issue analysis task.
+
+        Submission registers the event before creating the asyncio task.  Direct
+        callers are supported as well, so this wrapper registers a missing event
+        synchronously when the coroutine starts and always removes only its own
+        task entry after the worker has finished.
+        """
+        task_id = str(issue_info.get("task_id") or uuid.uuid4())
+        task_key = self._make_task_key(issue_info)
+        task_events = getattr(self, "_cancel_events", {}).get(task_key, {})
+        registered_event = task_events.get(task_id)
+        if registered_event is None:
+            registered_event = self._register_task(
+                task_key,
+                task_id,
+                event=cancel_event,
+            )
+        current_task = asyncio.current_task()
+        if current_task is not None:
+            self._bind_task_handle(task_key, task_id, current_task)
+        try:
+            return await self._run_issue_analysis(
+                issue_info,
+                deadline=deadline,
+                cancel_event=registered_event,
+                task_id=task_id,
+            )
+        except asyncio.CancelledError as cancellation:
+            # ``task.cancel()`` can interrupt the worker outside the nested DB
+            # try block (notably while waiting for the semaphore).  If this
+            # task already created a row, finish that exact row in a fresh
+            # session after the original session has rolled back.
+            registered_event.set()
+            identity = self._get_analysis_record_identity(task_key, task_id)
+            terminal_status = IssueAnalysisStatus.CANCELLED.value
+            if identity is not None:
+                try:
+                    async with async_session() as cleanup_db:
+                        _, persisted_status = await self._converge_cancelled_analysis(
+                            cleanup_db,
+                            analysis_id=identity[0],
+                            issue_info=issue_info,
+                            reason=str(cancellation) or "Issue 分析已被取消",
+                        )
+                    if persisted_status in {
+                        IssueAnalysisStatus.COMPLETED.value,
+                        IssueAnalysisStatus.FAILED.value,
+                    }:
+                        terminal_status = persisted_status
+                except Exception as cleanup_exc:
+                    logger.warning(
+                        "[{}] 取消时收敛 Issue 分析记录失败: {}",
+                        task_id,
+                        cleanup_exc,
+                    )
+            execution = self._get_execution(task_key, task_id)
+            if (
+                execution is not None
+                and self._get_execution_status(task_key, task_id) is None
+            ):
+                try:
+                    await execution.finish(terminal_status, error_message=None)
+                except Exception as finish_exc:
+                    logger.warning(
+                        "[{}] 取消时 issue observability finish 失败 (status={}): {}",
+                        task_id,
+                        terminal_status,
+                        finish_exc,
+                    )
+                else:
+                    self._set_execution_status(task_key, task_id, terminal_status)
+            # Preserve normal asyncio cancellation semantics for direct callers;
+            # ``cancel_task`` consumes this result while awaiting the handle.
+            raise
+        finally:
+            self._unregister_task(task_key, task_id)
+
+    async def _run_issue_analysis(
+        self,
+        issue_info: dict[str, Any],
+        *,
+        deadline: AITaskDeadline | None = None,
+        cancel_event: asyncio.Event,
+        task_id: str,
     ) -> str:
         """处理 Issue 分析任务
 
@@ -107,12 +582,13 @@ class IssueWorker:
         task_deadline = deadline or AITaskDeadline.from_timeout(
             get_settings().review_timeout_seconds
         )
-        task_id = issue_info.get("task_id", str(uuid.uuid4()))
-
         repo_owner = issue_info.get("repo_owner", "")
         repo_name = issue_info.get("repo_name", "")
         issue_number = issue_info.get("issue_number", 0)
         repo_full_name = issue_info.get("repo_full_name", f"{repo_owner}/{repo_name}")
+        task_key = self._make_task_key(issue_info)
+        analysis_id: int | None = None
+        analysis_record: IssueAnalysis | None = None
 
         logger.info(f"[{task_id}] 开始处理 Issue 分析: {repo_full_name}#{issue_number}")
 
@@ -125,7 +601,7 @@ class IssueWorker:
         ) -> None:
             """Best-effort terminal convergence for the observability bundle."""
             nonlocal execution_status, execution_target_status
-            if execution is None or execution_status == status:
+            if execution is None or execution_status is not None:
                 return
             execution_target_status = status
             try:
@@ -139,19 +615,26 @@ class IssueWorker:
                 )
                 return
             execution_status = status
+            self._set_execution_status(task_key, task_id, status)
 
         @asynccontextmanager
         async def _execution_scope():
             """Keep cancellation cleanup around semaphore and DB admission."""
+            cancellation_pending = False
             try:
                 semaphore = await _get_issue_semaphore()
                 async with semaphore:
                     yield
             except asyncio.CancelledError:
-                await _finish_execution("cancelled")
+                # The ORM record captured by this task may be stale: an
+                # independent lifecycle transaction can complete/fail it while
+                # this task is being cancelled.  Let the outer
+                # ``process_issue_analysis`` handler refresh the exact row in a
+                # fresh session and decide the execution terminal state.
+                cancellation_pending = True
                 raise
             finally:
-                if execution is not None and execution_status is None:
+                if not cancellation_pending and execution is not None and execution_status is None:
                     await _finish_execution(
                         execution_target_status or "failed",
                         error_message=(
@@ -193,6 +676,7 @@ class IssueWorker:
                     execution.invocation_id,
                 )
                 return task_id
+            self._bind_execution(task_key, task_id, execution)
         except Exception as observability_exc:
             # Observability admission is best-effort for legacy callers that lack
             # immutable repository identity; the core analysis still runs, but
@@ -209,11 +693,15 @@ class IssueWorker:
         async with _execution_scope():
             async with async_session() as db:
                 try:
+                    # Check after semaphore admission so a queued task that was
+                    # cancelled never creates an analysis record or calls AI.
+                    self._raise_if_cancelled(cancel_event)
                     # 1. 计算下一个分析版本号
                     max_version = await db.scalar(
                         select(func.max(IssueAnalysis.analysis_version)).where(
                             and_(
                                 IssueAnalysis.repo_name == repo_name,
+                                IssueAnalysis.repo_owner == repo_owner,
                                 IssueAnalysis.issue_number == issue_number,
                             )
                         )
@@ -234,6 +722,9 @@ class IssueWorker:
                     )
                     db.add(record)
                     await db.commit()
+                    analysis_id = record.id
+                    analysis_record = record
+                    self._bind_analysis_record(task_key, task_id, record)
                     await db.refresh(record)
 
                     # 2. 更新状态为 ANALYZING
@@ -273,9 +764,11 @@ class IssueWorker:
                         logger.warning(f"发布 SSE 事件失败（不影响主流程）: {e}")
 
                     # 3. 获取 repo 对象
+                    self._raise_if_cancelled(cancel_event)
                     client = self.github_app.get_repo_client(repo_owner, repo_name)
                     repo = None
                     if client:
+                        self._raise_if_cancelled(cancel_event)
                         repo = client.get_repo(repo_full_name)
 
                     # 4. 调用 AI 分析：对话流持久化到新可观测性 Canonical Transcript
@@ -326,6 +819,7 @@ class IssueWorker:
                         except Exception as exc:
                             logger.debug("issue observability callback failed: {}", exc)
 
+                    self._raise_if_cancelled(cancel_event)
                     analysis_result = await self.analyzer.analyze_issue(
                         issue_info=issue_info,
                         repo_owner=repo_owner,
@@ -343,27 +837,58 @@ class IssueWorker:
                             else None
                         ),
                         observer=execution.observer if execution is not None else None,
+                        cancel_event=cancel_event,
                         deadline=task_deadline,
                     )
+                    self._raise_if_cancelled(cancel_event)
 
                     # WorkUnit 终态由 execution.finish("completed") 统一收敛（见下方
                     # 成功路径），分析结果摘要持久化在 IssueAnalysis 记录中。
 
                     # 5. 保存分析结果（更新已有的 PENDING 记录）
+                    self._raise_if_cancelled(cancel_event)
                     analysis_record = await issue_service.save_analysis_result(
-                        analysis_result, issue_info, db
+                        analysis_result,
+                        issue_info,
+                        db,
+                        analysis_id=analysis_id,
                     )
 
                     if not analysis_record:
-                        logger.error(f"[{task_id}] 未找到待更新的分析记录")
-                        if execution is not None:
-                            await _finish_execution(
-                                "failed",
-                                error_message="未找到待更新的 Issue 分析记录",
+                        # The conditional save can lose a close/cancel/delete
+                        # race after the worker's initial read.  This is a
+                        # normal stale-worker outcome, not an analysis failure.
+                        logger.info(
+                            "[{}] Issue 分析记录已由生命周期操作收敛，跳过后续副作用",
+                            task_id,
+                        )
+                        try:
+                            _, cancellation_status = await self._converge_cancelled_analysis(
+                                db,
+                                analysis_id=analysis_id,
+                                issue_info=issue_info,
+                                reason="Issue 分析记录已关闭或被删除",
                             )
+                        except Exception as cancel_exc:
+                            logger.warning(
+                                "[{}] 保存竞态后的取消收敛失败: {}",
+                                task_id,
+                                cancel_exc,
+                            )
+                            cancellation_status = None
+                        await _finish_execution(
+                            cancellation_status
+                            if cancellation_status
+                            in {
+                                IssueAnalysisStatus.COMPLETED.value,
+                                IssueAnalysisStatus.FAILED.value,
+                            }
+                            else "cancelled"
+                        )
                         return task_id
 
                     # 5.1 关联扫描记录（如果此 Issue 来自仓库扫描）
+                    self._raise_if_cancelled(cancel_event)
                     try:
                         from backend.models.scan_models import RepoScan
 
@@ -374,14 +899,18 @@ class IssueWorker:
                         )
                         if scan and not scan.issue_analysis_id:
                             scan.issue_analysis_id = analysis_record.id
+                            self._raise_if_cancelled(cancel_event)
                             await db.commit()
                             logger.info(
                                 f"[{task_id}] 已关联扫描记录到分析: scan_id={scan.id}"
                             )
+                    except ReviewCancelledError:
+                        raise
                     except Exception as e:
                         logger.warning(f"[{task_id}] 关联扫描记录失败: {e}")
 
                     # 5.5 使用 AI 摘要更新 Issue 向量
+                    self._raise_if_cancelled(cancel_event)
                     try:
                         from backend.services.issue_embedding_service import (
                             IssueEmbeddingService,
@@ -395,6 +924,7 @@ class IssueWorker:
                                 "priority": analysis_result.get("priority", ""),
                                 "feasibility": analysis_result.get("feasibility", ""),
                             }
+                            self._raise_if_cancelled(cancel_event)
                             await emb_service.upsert_issue(
                                 repo_owner,
                                 repo_name,
@@ -410,14 +940,18 @@ class IssueWorker:
                                 f"[{task_id}] 软 deadline 已到达，"
                                 "跳过 Issue 向量辅助调用"
                             )
+                    except ReviewCancelledError:
+                        raise
                     except Exception as e:
                         logger.warning(f"[{task_id}] 使用 AI 摘要更新向量失败: {e}")
 
                     # 6. 重复检测（优先使用 AI 摘要）
+                    self._raise_if_cancelled(cancel_event)
                     if (
                         not task_deadline.is_expired()
                         and await get_dynamic_config("issue_detect_duplicates")
                     ):
+                        self._raise_if_cancelled(cancel_event)
                         try:
                             summary = analysis_result.get("summary", "")
                             duplicates = await issue_service.detect_duplicates(
@@ -431,10 +965,13 @@ class IssueWorker:
                                 analysis_record.duplicate_of = duplicates[0].get(
                                     "issue_number"
                                 )
+                        except ReviewCancelledError:
+                            raise
                         except Exception as e:
                             logger.warning(f"[{task_id}] 重复检测失败: {e}")
 
                     # 7. 查找关联 PR
+                    self._raise_if_cancelled(cancel_event)
                     try:
                         related_prs = await issue_service.find_related_prs(
                             repo_owner, repo_name, issue_number
@@ -443,12 +980,16 @@ class IssueWorker:
                             analysis_record.related_prs = json.dumps(
                                 related_prs, ensure_ascii=False
                             )
+                    except ReviewCancelledError:
+                        raise
                     except Exception as e:
                         logger.warning(f"[{task_id}] 查找关联 PR 失败: {e}")
 
+                    self._raise_if_cancelled(cancel_event)
                     await db.commit()
 
                     # 发布 SSE 事件通知前端（完成）
+                    self._raise_if_cancelled(cancel_event)
                     try:
                         from backend.webui.sse import publish_event
 
@@ -460,9 +1001,12 @@ class IssueWorker:
                                 "status": "completed",
                             },
                         )
+                    except ReviewCancelledError:
+                        raise
                     except Exception as e:
                         logger.warning(f"发布 SSE 事件失败（不影响主流程）: {e}")
 
+                    self._raise_if_cancelled(cancel_event)
                     await self._log_activity(
                         record.id,
                         "result",
@@ -475,6 +1019,7 @@ class IssueWorker:
                     )
 
                     # 8. 自动评论
+                    self._raise_if_cancelled(cancel_event)
                     try:
                         activity_result_id = analysis_result.get("_activity_result_id")
                         if execution is not None and isinstance(
@@ -484,6 +1029,7 @@ class IssueWorker:
                             if not body:
                                 success = False
                             else:
+                                self._raise_if_cancelled(cancel_event)
                                 publication = (
                                     await execution.publication_service.create_pending(
                                         activity_result_id,
@@ -520,6 +1066,7 @@ class IssueWorker:
                                         raise_on_error=True,
                                     )
 
+                                self._raise_if_cancelled(cancel_event)
                                 terminal = await execution.publication_service.send(
                                     publication.id,
                                     body=body,
@@ -531,6 +1078,7 @@ class IssueWorker:
                                     analysis_record.comment_posted = 1
                                     await db.commit()
                         else:
+                            self._raise_if_cancelled(cancel_event)
                             success = await issue_service.post_analysis_comment(
                                 repo_owner,
                                 repo_name,
@@ -540,15 +1088,19 @@ class IssueWorker:
                             )
                         if success:
                             logger.info(f"[{task_id}] 已发布分析评论")
+                    except ReviewCancelledError:
+                        raise
                     except Exception as e:
                         logger.warning(f"[{task_id}] 发布评论失败: {e}")
 
                     # 10. 应用建议标签；enabled、阈值与 auto_create 由 IssueService 统一处理。
+                    self._raise_if_cancelled(cancel_event)
                     try:
                         labels_data = json.loads(
                             analysis_record.suggested_labels or "[]"
                         )
                         if labels_data:
+                            self._raise_if_cancelled(cancel_event)
                             result = await issue_service.apply_suggested_labels(
                                 repo_owner,
                                 repo_name,
@@ -569,16 +1121,21 @@ class IssueWorker:
                                 logger.warning(
                                     f"[{task_id}] 标签应用失败: {result['failed']}"
                                 )
+                    except ReviewCancelledError:
+                        raise
                     except Exception as e:
                         logger.warning(f"[{task_id}] 应用标签失败: {e}")
 
                     # 10.5 应用建议指派人
+                    self._raise_if_cancelled(cancel_event)
                     if await get_dynamic_config("issue_auto_assign"):
+                        self._raise_if_cancelled(cancel_event)
                         try:
                             assignees_data = json.loads(
                                 analysis_record.suggested_assignees or "[]"
                             )
                             if assignees_data:
+                                self._raise_if_cancelled(cancel_event)
                                 assign_result = (
                                     await issue_service.apply_suggested_assignees(
                                         repo_owner,
@@ -597,19 +1154,24 @@ class IssueWorker:
                                         f"[{task_id}] 指派失败: "
                                         f"{[a['username'] for a in assign_result['failed']]}"
                                     )
+                        except ReviewCancelledError:
+                            raise
                         except Exception as e:
                             logger.warning(f"[{task_id}] 应用指派人失败: {e}")
 
                     # 10.7 自动改写标题（优先从 DB 读取配置）
+                    self._raise_if_cancelled(cancel_event)
                     issue_auto_rewrite_title = await get_dynamic_config(
                         "issue_auto_rewrite_title"
                     )
 
                     if issue_auto_rewrite_title:
+                        self._raise_if_cancelled(cancel_event)
                         try:
                             suggested_title = analysis_record.suggested_title
                             original_title = issue_info.get("title", "")
                             if suggested_title and suggested_title != original_title:
+                                self._raise_if_cancelled(cancel_event)
                                 success = await asyncio.to_thread(
                                     self.github_app.update_issue_title,
                                     repo_owner,
@@ -621,6 +1183,8 @@ class IssueWorker:
                                     logger.info(
                                         f"[{task_id}] 已改写标题: {suggested_title}"
                                     )
+                        except ReviewCancelledError:
+                            raise
                         except Exception as e:
                             logger.warning(f"[{task_id}] 改写标题失败: {e}")
 
@@ -630,6 +1194,7 @@ class IssueWorker:
 
                     # 收集通知目标：作者 + 订阅者
                     notification_chat_ids = []
+                    self._raise_if_cancelled(cancel_event)
                     try:
                         from backend.services.telegram_service import TelegramService
 
@@ -637,10 +1202,13 @@ class IssueWorker:
                         notification_chat_ids = await ts.get_notification_targets(
                             repo_full_name, issue_info.get("author", "")
                         )
+                    except ReviewCancelledError:
+                        raise
                     except Exception as e:
                         logger.warning(f"[{task_id}] 获取通知目标失败: {e}")
 
                     if priority == "critical":
+                        self._raise_if_cancelled(cancel_event)
                         try:
                             from backend.telegram.notifications import (
                                 get_notification_sender,
@@ -648,6 +1216,7 @@ class IssueWorker:
 
                             sender = get_notification_sender()
                             if sender and notification_chat_ids:
+                                self._raise_if_cancelled(cancel_event)
                                 await sender.send_critical_issue_alert(
                                     repo_name=repo_full_name,
                                     issue_number=issue_number,
@@ -662,10 +1231,13 @@ class IssueWorker:
                                     chat_ids=notification_chat_ids,
                                 )
                                 logger.info(f"[{task_id}] 已发送 Critical Issue 告警")
+                        except ReviewCancelledError:
+                            raise
                         except Exception as e:
                             logger.warning(f"[{task_id}] 发送告警失败: {e}")
 
                     # 12. 发送完成通知
+                    self._raise_if_cancelled(cancel_event)
                     try:
                         from backend.telegram.notifications import (
                             get_notification_sender,
@@ -673,6 +1245,7 @@ class IssueWorker:
 
                         sender = get_notification_sender()
                         if sender and notification_chat_ids:
+                            self._raise_if_cancelled(cancel_event)
                             await sender.send_issue_analysis_complete(
                                 repo_name=repo_full_name,
                                 issue_number=issue_number,
@@ -682,10 +1255,13 @@ class IssueWorker:
                                 summary=analysis_result.get("summary"),
                                 chat_ids=notification_chat_ids,
                             )
+                    except ReviewCancelledError:
+                        raise
                     except Exception as e:
                         logger.warning(f"[{task_id}] 发送完成通知失败: {e}")
 
                     # 13. 异步触发 .sakura/ Issue 反思 / Trigger .sakura/ issue reflection async
+                    self._raise_if_cancelled(cancel_event)
                     try:
                         sm_config = get_sakura_memory_config()
                         if (
@@ -695,12 +1271,14 @@ class IssueWorker:
                                 "issue_reflection", {}
                             ).get("enabled", True)
                         ):
+                            self._raise_if_cancelled(cancel_event)
                             from backend.services.sakura_memory_service import (
                                 get_sakura_memory_service,
                             )
 
                             sakura_memory_service = get_sakura_memory_service()
                             ensure_background_admission("issue_reflection")
+                            self._raise_if_cancelled(cancel_event)
                             task = asyncio.create_task(
                                 sakura_memory_service.reflect_issue(
                                     repo=repo,
@@ -723,6 +1301,8 @@ class IssueWorker:
                             self._background_tasks.add(task)
                             task.add_done_callback(self._background_tasks.discard)
                             logger.info(f"[{task_id}] 已触发 .sakura/ Issue 反思任务")
+                    except ReviewCancelledError:
+                        raise
                     except Exception as e:
                         logger.warning(
                             f"[{task_id}] 触发 .sakura/ Issue 反思失败（不影响分析）: {e}"
@@ -738,40 +1318,150 @@ class IssueWorker:
                         analysis_result.get("completion_tokens", 0),
                         analysis_result.get("estimated_cost", 0),
                     )
+                    self._raise_if_cancelled(cancel_event)
                     if execution is not None:
                         await _finish_execution("completed")
 
-                except Exception as e:
-                    logger.error(f"[{task_id}] Issue 分析失败: {e}", exc_info=True)
-                    if execution is not None:
-                        await _finish_execution("failed", error_message=str(e))
-
-                    # 更新状态为 FAILED（仅更新本次任务的 PENDING/ANALYZING 记录）
+                except ReviewCancelledError as e:
+                    logger.info("[{}] Issue 分析已取消: {}", task_id, e)
+                    cancellation_status = None
                     try:
-                        result = await db.execute(
-                            select(IssueAnalysis)
-                            .where(
-                                and_(
-                                    IssueAnalysis.issue_number == issue_number,
-                                    IssueAnalysis.repo_name == repo_name,
-                                    IssueAnalysis.status.in_(
-                                        [
-                                            IssueAnalysisStatus.PENDING.value,
-                                            IssueAnalysisStatus.ANALYZING.value,
-                                        ]
-                                    ),
+                        _, cancellation_status = await self._converge_cancelled_analysis(
+                            db,
+                            analysis_id=analysis_id,
+                            issue_info=issue_info,
+                            reason=str(e),
+                        )
+                    except Exception as cancel_exc:
+                        logger.warning(
+                            "[{}] 收敛 Issue 取消状态失败: {}",
+                            task_id,
+                            cancel_exc,
+                        )
+                    await _finish_execution(
+                        cancellation_status
+                        if cancellation_status
+                        in {
+                            IssueAnalysisStatus.COMPLETED.value,
+                            IssueAnalysisStatus.FAILED.value,
+                        }
+                        else "cancelled"
+                    )
+                    return task_id
+                except Exception as e:
+                    # A cancellation signal may race a provider/DB exception.
+                    # Once the lifecycle is cancelled/closed, never overwrite
+                    # it with FAILED.
+                    lifecycle_cancelled = cancel_event.is_set()
+                    current_record = None
+                    try:
+                        if analysis_id is not None and not lifecycle_cancelled:
+                            state_result = await db.execute(
+                                select(IssueAnalysis).where(
+                                    IssueAnalysis.id == analysis_id
                                 )
                             )
-                            .order_by(IssueAnalysis.created_at.desc())
-                            .limit(1)
+                            current_record = state_result.scalar_one_or_none()
+                            current_status = getattr(current_record, "status", None)
+                            lifecycle_cancelled = current_record is None or (
+                                current_status == IssueAnalysisStatus.CANCELLED.value
+                                or (
+                                    current_status
+                                    not in {
+                                        IssueAnalysisStatus.COMPLETED.value,
+                                        IssueAnalysisStatus.FAILED.value,
+                                    }
+                                    and getattr(current_record, "issue_state", None)
+                                    == "closed"
+                                )
+                            )
+                    except Exception as state_exc:
+                        logger.debug(
+                            "[{}] 检查 Issue 生命周期状态失败: {}",
+                            task_id,
+                            state_exc,
                         )
-                        record = result.scalar_one_or_none()
-                        if record:
-                            record.status = IssueAnalysisStatus.FAILED.value
-                            record.error_message = str(e)
-                            await db.commit()
+
+                    if lifecycle_cancelled:
+                        cancellation_status = None
+                        try:
+                            _, cancellation_status = await self._converge_cancelled_analysis(
+                                db,
+                                analysis_id=analysis_id,
+                                issue_info=issue_info,
+                                reason=str(e) or "Issue 分析已被取消",
+                            )
+                        except Exception as cancel_exc:
+                            logger.warning(
+                                "[{}] 异常后收敛 Issue 取消状态失败: {}",
+                                task_id,
+                                cancel_exc,
+                            )
+                        await _finish_execution(
+                            cancellation_status
+                            if cancellation_status
+                            in {
+                                IssueAnalysisStatus.COMPLETED.value,
+                                IssueAnalysisStatus.FAILED.value,
+                            }
+                            else "cancelled"
+                        )
+                        return task_id
+
+                    logger.error(f"[{task_id}] Issue 分析失败: {e}", exc_info=True)
+
+                    # Update FAILED only for this task's active exact row.  A
+                    # rowcount of zero means another lifecycle transition won;
+                    # classify it as cancellation rather than failure.
+                    failed_record = None
+                    try:
+                        failed_record = await self._mark_analysis_failed(
+                            db,
+                            analysis_id=analysis_id,
+                            reason=str(e),
+                        )
+                        failed_status = getattr(failed_record, "status", None)
+                        failed_is_cancelled = analysis_id is not None and (
+                            failed_record is None
+                            or (
+                                failed_status
+                                not in {
+                                    IssueAnalysisStatus.COMPLETED.value,
+                                    IssueAnalysisStatus.FAILED.value,
+                                }
+                                and (
+                                    failed_status
+                                    == IssueAnalysisStatus.CANCELLED.value
+                                    or getattr(failed_record, "issue_state", None)
+                                    == "closed"
+                                )
+                            )
+                        )
+                        if failed_is_cancelled:
+                            _, cancellation_status = await self._converge_cancelled_analysis(
+                                db,
+                                analysis_id=analysis_id,
+                                issue_info=issue_info,
+                                reason=str(e) or "Issue 分析已被取消",
+                            )
+                            await _finish_execution(
+                                cancellation_status
+                                if cancellation_status
+                                in {
+                                    IssueAnalysisStatus.COMPLETED.value,
+                                    IssueAnalysisStatus.FAILED.value,
+                                }
+                                else "cancelled"
+                            )
+                            return task_id
+
+                        if failed_status == IssueAnalysisStatus.COMPLETED.value:
+                            await _finish_execution("completed")
+                            return task_id
+
+                        if failed_record is not None:
                             await self._log_activity(
-                                record.id,
+                                failed_record.id,
                                 "error",
                                 {
                                     "message": f"Issue 分析失败: {e!s}",
@@ -785,15 +1475,24 @@ class IssueWorker:
                                 await publish_event(
                                     "issue:status_changed",
                                     {
-                                        "issue_number": issue_info.get("issue_number"),
+                                        "issue_number": issue_info.get(
+                                            "issue_number"
+                                        ),
                                         "repo_name": issue_info.get("repo_name"),
                                         "status": "failed",
                                     },
                                 )
                             except Exception:
                                 pass
-                    except Exception:
-                        pass
+                    except Exception as failure_exc:
+                        logger.warning(
+                            "[{}] 更新 Issue 失败状态失败: {}",
+                            task_id,
+                            failure_exc,
+                        )
+
+                    if execution is not None:
+                        await _finish_execution("failed", error_message=str(e))
 
         return task_id
 
@@ -816,17 +1515,44 @@ async def submit_issue_analysis_task(issue_info: dict[str, Any]) -> str:
     issue_info["task_id"] = task_id
     worker = get_issue_worker()
     deadline = AITaskDeadline.from_timeout(get_settings().review_timeout_seconds)
-    task = asyncio.create_task(
-        worker.process_issue_analysis(issue_info, deadline=deadline)
+    task_key = worker._make_task_key(issue_info)
+    cancel_event = worker._register_task(
+        task_key,
+        task_id,
     )
+    task: asyncio.Task[Any] | None = None
     try:
+        task = asyncio.create_task(
+            worker.process_issue_analysis(
+                issue_info,
+                deadline=deadline,
+                cancel_event=cancel_event,
+            )
+        )
+        worker._bind_task_handle(task_key, task_id, task)
         register_background_task(task, "issue")
     except DatabaseResetRuntimeAdmissionClosed:
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception as cleanup_exc:
+                logger.warning(
+                    "[{}] 清理未登记的 Issue 任务失败: {}",
+                    task_id,
+                    cleanup_exc,
+                )
+        # The coroutine may never have started, so its ``finally`` cannot
+        # unregister the pre-created entry.  Always remove it explicitly when
+        # admission rejects the background handle.
+        worker._unregister_task(task_key, task_id)
+        raise
+    except BaseException:
+        # Do not leak a pre-registration if task creation itself is rejected.
+        if task is None:
+            worker._unregister_task(task_key, task_id)
         raise
     worker._background_tasks.add(task)
     task.add_done_callback(worker._background_tasks.discard)

--- a/tests/test_activity_observability_integration.py
+++ b/tests/test_activity_observability_integration.py
@@ -28,6 +28,7 @@ from backend.services.activity_observability.contracts import RoleConfigSnapshot
 from backend.services.activity_observability.integration_service import (
     ActivityIntegrationService,
     AdmissionError,
+    ObservedExecutionBundle,
 )
 
 
@@ -270,6 +271,128 @@ async def test_cancelled_execution_stops_lease_heartbeat_and_releases_lease(
     stored_work_unit = await db.get(ActivityInvocationWorkUnit, execution.work_unit.id)
     assert stored_work_unit.status == "cancelled"
     assert await db.get(ActivityThreadLease, execution.thread.id) is None
+
+
+@pytest.mark.asyncio
+async def test_start_execution_cleans_up_when_bundle_build_fails(
+    db, resource, snapshot
+):
+    """A committed admission must not strand its queued work unit on build failure."""
+    service = ActivityIntegrationService(db=db)
+    admitted = await service.admit_synchronize(
+        resource, delivery_id="admission-build-failure"
+    )
+
+    async def fail_build(*_args, **_kwargs):
+        raise RuntimeError("bundle construction failed")
+
+    service.build_execution_bundle = fail_build
+
+    with pytest.raises(RuntimeError, match="bundle construction failed"):
+        await service.start_execution(
+            session_id=admitted.session_id,
+            trigger_ids=[admitted.trigger_id],
+            role_snapshot=snapshot,
+        )
+
+    invocations = (
+        (
+            await db.execute(
+                select(ActivityInvocation).where(
+                    ActivityInvocation.session_id == admitted.session_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(invocations) == 1
+    work_unit = await db.get(ActivityInvocationWorkUnit, invocations[0].id)
+    assert work_unit is not None
+    assert work_unit.status == "failed"
+    assert work_unit.error_message == "bundle construction failed"
+    assert await db.get(ActivityThreadLease, work_unit.thread_id) is None
+
+
+@pytest.mark.asyncio
+async def test_start_execution_cleans_up_when_admission_is_cancelled(
+    db, resource, snapshot
+):
+    """Cancellation after durable admission converges the exact work unit."""
+    service = ActivityIntegrationService(db=db)
+    admitted = await service.admit_synchronize(
+        resource, delivery_id="admission-cancelled"
+    )
+
+    async def cancel_build(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    service.build_execution_bundle = cancel_build
+
+    with pytest.raises(asyncio.CancelledError):
+        await service.start_execution(
+            session_id=admitted.session_id,
+            trigger_ids=[admitted.trigger_id],
+            role_snapshot=snapshot,
+        )
+
+    invocations = (
+        (
+            await db.execute(
+                select(ActivityInvocation).where(
+                    ActivityInvocation.session_id == admitted.session_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(invocations) == 1
+    work_unit = await db.get(ActivityInvocationWorkUnit, invocations[0].id)
+    assert work_unit is not None
+    assert work_unit.status == "cancelled"
+    assert await db.get(ActivityThreadLease, work_unit.thread_id) is None
+
+
+@pytest.mark.asyncio
+async def test_start_execution_cleans_up_when_heartbeat_start_fails(
+    db, resource, snapshot, monkeypatch
+):
+    """A heartbeat startup error finishes and releases the newly admitted lane."""
+    service = ActivityIntegrationService(db=db)
+    admitted = await service.admit_synchronize(
+        resource, delivery_id="admission-heartbeat-failure"
+    )
+
+    def fail_heartbeat(_bundle):
+        raise RuntimeError("heartbeat startup failed")
+
+    monkeypatch.setattr(ObservedExecutionBundle, "start_lease_heartbeat", fail_heartbeat)
+
+    with pytest.raises(RuntimeError, match="heartbeat startup failed"):
+        await service.start_execution(
+            session_id=admitted.session_id,
+            trigger_ids=[admitted.trigger_id],
+            role_snapshot=snapshot,
+        )
+
+    invocations = (
+        (
+            await db.execute(
+                select(ActivityInvocation).where(
+                    ActivityInvocation.session_id == admitted.session_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(invocations) == 1
+    work_unit = await db.get(ActivityInvocationWorkUnit, invocations[0].id)
+    assert work_unit is not None
+    assert work_unit.status == "failed"
+    assert work_unit.error_message == "heartbeat startup failed"
+    assert await db.get(ActivityThreadLease, work_unit.thread_id) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_issue_cancellation_propagation.py
+++ b/tests/test_issue_cancellation_propagation.py
@@ -1,0 +1,232 @@
+"""Focused cancellation propagation tests for Issue analysis protocol paths."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import backend.services.issue_analyzer as issue_analyzer_module
+import backend.services.protocol_repair as protocol_repair_module
+from backend.core.ai_protocol.errors import ReviewCancelledError
+from backend.services.ai_task_deadline import AITaskDeadline
+from backend.services.issue_analyzer import IssueAnalyzer
+from backend.services.issue_protocol import IssueProtocolError
+from backend.services.protocol_repair import run_protocol_repair_loop
+
+
+async def _async_result(value):
+    return value
+
+
+def _configure_analyzer(monkeypatch, analyzer, client):
+    class _Settings:
+        review_timeout_seconds = 120
+        ai_temperature = 0.2
+        issue_price_per_1k_prompt = 1
+        issue_price_per_1k_completion = 1
+
+    analyzer.api_client = client
+    analyzer.tool_manager = SimpleNamespace(
+        get_enabled_tools=lambda _repo: _async_result([])
+    )
+    analyzer._refresh_ai_client = lambda: None
+    analyzer._refresh_runtime_config = lambda: None
+    analyzer._build_system_prompt = lambda *_args, **_kwargs: "system"
+    analyzer._build_user_message = lambda *_args, **_kwargs: "user"
+
+    async def get_repo_labels(*_args):
+        return {}
+
+    async def get_sakura_context(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(issue_analyzer_module, "get_settings", lambda: _Settings())
+    monkeypatch.setattr(
+        issue_analyzer_module,
+        "get_user_dynamic_config",
+        lambda *_args: _async_result("en"),
+    )
+    monkeypatch.setattr(
+        issue_analyzer_module,
+        "get_dynamic_config",
+        lambda _key: _async_result(False),
+    )
+    monkeypatch.setattr(
+        issue_analyzer_module,
+        "get_model_context_manager",
+        lambda: SimpleNamespace(calculate_safe_context=lambda *_args: 80_000),
+    )
+    monkeypatch.setattr(
+        "backend.services.label_service.label_service.get_repo_labels",
+        get_repo_labels,
+    )
+    monkeypatch.setattr(
+        "backend.core.github_app.GitHubAppClient",
+        lambda: SimpleNamespace(get_repo_collaborators=lambda *_args: []),
+    )
+    monkeypatch.setattr(
+        "backend.services.sakura_memory_service.get_sakura_memory_service",
+        lambda: SimpleNamespace(get_sakura_context=get_sakura_context),
+    )
+
+
+def _issue_info():
+    return {
+        "issue_number": 1,
+        "title": "title",
+        "body": "body",
+        "author": "author",
+        "state": "open",
+    }
+
+
+@pytest.mark.asyncio
+async def test_issue_analyzer_reraises_provider_cancellation(monkeypatch):
+    cancellation = ReviewCancelledError("provider cancelled")
+
+    class _Client:
+        async def resolve_role_model_context(self, _role):
+            return "model-x", 100_000
+
+        async def call_with_retry(self, **_kwargs):
+            raise cancellation
+
+    analyzer = IssueAnalyzer.__new__(IssueAnalyzer)
+    _configure_analyzer(monkeypatch, analyzer, _Client())
+
+    with pytest.raises(ReviewCancelledError) as raised:
+        await analyzer.analyze_issue(
+            _issue_info(),
+            "owner",
+            "repo",
+            cancel_event=SimpleNamespace(is_set=lambda: False),
+            deadline=AITaskDeadline.from_timeout(120),
+        )
+
+    assert raised.value is cancellation
+
+
+@pytest.mark.asyncio
+async def test_issue_analyzer_rechecks_cancellation_at_repair_return(monkeypatch):
+    analyzer = IssueAnalyzer.__new__(IssueAnalyzer)
+    analyzer.api_client = SimpleNamespace()
+    cancelled = SimpleNamespace(value=False)
+
+    async def fake_repair_loop(**_kwargs):
+        cancelled.value = True
+        return {"parse_source": "test"}
+
+    monkeypatch.setattr(
+        issue_analyzer_module,
+        "run_protocol_repair_loop",
+        fake_repair_loop,
+    )
+    monkeypatch.setattr(
+        issue_analyzer_module,
+        "get_dynamic_config",
+        lambda _key: _async_result(1),
+    )
+
+    with pytest.raises(ReviewCancelledError):
+        await analyzer._parse_or_repair_analysis(
+            "response",
+            [],
+            SimpleNamespace(),
+            cancel_event=SimpleNamespace(is_set=lambda: cancelled.value),
+        )
+
+
+@pytest.mark.asyncio
+async def test_protocol_repair_reraises_provider_cancellation(monkeypatch):
+    cancellation = ReviewCancelledError("repair cancelled")
+    fallback_calls = []
+
+    class _Client:
+        async def call_with_retry(self, **_kwargs):
+            raise cancellation
+
+    def parse_fn(_text):
+        raise IssueProtocolError("invalid envelope")
+
+    async def no_publish(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(protocol_repair_module, "publish_event", no_publish)
+
+    with pytest.raises(ReviewCancelledError) as raised:
+        await run_protocol_repair_loop(
+            parse_fn=parse_fn,
+            error_type=IssueProtocolError,
+            base_messages=[],
+            final_text="invalid",
+            repair_instruction="repair",
+            api_client=_Client(),
+            tracker=SimpleNamespace(accumulate=lambda _response: None),
+            max_attempts=1,
+            fallback_result_fn=lambda error: fallback_calls.append(error) or {},
+            log_label="Issue 分析",
+            sse_channel="issue:protocol_repair",
+        )
+
+    assert raised.value is cancellation
+    assert fallback_calls == []
+
+
+@pytest.mark.asyncio
+async def test_protocol_repair_preserves_fallback_for_regular_error(monkeypatch):
+    class _Client:
+        async def call_with_retry(self, **_kwargs):
+            raise RuntimeError("network down")
+
+    def parse_fn(_text):
+        raise IssueProtocolError("invalid envelope")
+
+    fallback_errors = []
+
+    async def no_publish(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(protocol_repair_module, "publish_event", no_publish)
+
+    result = await run_protocol_repair_loop(
+        parse_fn=parse_fn,
+        error_type=IssueProtocolError,
+        base_messages=[],
+        final_text="invalid",
+        repair_instruction="repair",
+        api_client=_Client(),
+        tracker=SimpleNamespace(accumulate=lambda _response: None),
+        max_attempts=1,
+        fallback_result_fn=lambda error: fallback_errors.append(error)
+        or {"parse_source": "fallback"},
+        log_label="Issue 分析",
+        sse_channel="issue:protocol_repair",
+    )
+
+    assert result == {"parse_source": "fallback"}
+    assert len(fallback_errors) == 1
+    assert isinstance(fallback_errors[0], RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_protocol_repair_rechecks_cancellation_before_success_return():
+    cancelled = SimpleNamespace(value=False)
+
+    async def on_repaired(*_args):
+        cancelled.value = True
+
+    with pytest.raises(ReviewCancelledError):
+        await run_protocol_repair_loop(
+            parse_fn=lambda _text: {"ok": True},
+            error_type=IssueProtocolError,
+            base_messages=[],
+            final_text="valid",
+            repair_instruction="repair",
+            api_client=SimpleNamespace(),
+            tracker=SimpleNamespace(),
+            max_attempts=1,
+            fallback_result_fn=lambda _error: {"fallback": True},
+            log_label="Issue 分析",
+            sse_channel="issue:protocol_repair",
+            on_repaired=on_repaired,
+            cancel_event=SimpleNamespace(is_set=lambda: cancelled.value),
+        )

--- a/tests/test_issue_cancellation_races.py
+++ b/tests/test_issue_cancellation_races.py
@@ -1,0 +1,474 @@
+"""Regression tests for Issue worker cancellation and persistence races."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.core.ai_protocol.errors import ReviewCancelledError
+from backend.services.database_reset_runtime_service import (
+    DatabaseResetRuntimeAdmissionClosed,
+)
+from backend.services.issue_service import IssueService
+from backend.workers import issue_worker as issue_worker_module
+from backend.workers.issue_worker import IssueWorker
+
+
+class _Result:
+    def __init__(self, record=None, *, rowcount=None):
+        self._record = record
+        self.rowcount = rowcount
+
+    def scalar_one_or_none(self):
+        return self._record
+
+
+class _RecordingSession:
+    def __init__(self, record=None, *, update_rowcount=1):
+        self.record = record
+        self.update_rowcount = update_rowcount
+        self.selects = []
+        self.updates = []
+        self.commits = 0
+
+    async def execute(self, statement):
+        if getattr(statement, "is_update", False):
+            self.updates.append(statement)
+            return _Result(rowcount=self.update_rowcount)
+        self.selects.append(statement)
+        return _Result(self.record)
+
+    async def commit(self):
+        self.commits += 1
+
+    async def refresh(self, _record):
+        return None
+
+
+class _SessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def _issue_info(task_id="issue-task", *, owner="owner", repo="repo"):
+    return {
+        "task_id": task_id,
+        "repo_owner": owner,
+        "repo_name": repo,
+        "repo_full_name": f"{owner}/{repo}",
+        "issue_number": 7,
+        "title": "Issue",
+        "body": "Body",
+        "state": "open",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_cancels_and_awaits_semaphore_wait(monkeypatch):
+    """A task blocked on admission must finish before lifecycle cleanup runs."""
+    execution = SimpleNamespace(merged=False, finish=AsyncMock())
+    integration = SimpleNamespace(
+        admit_issue=AsyncMock(return_value=SimpleNamespace(session_id=1, trigger_id=2)),
+        start_execution=AsyncMock(return_value=execution),
+    )
+    worker = IssueWorker.__new__(IssueWorker)
+    worker.activity_integration = integration
+    worker.analyzer = SimpleNamespace(api_client=None)
+    worker._background_tasks = set()
+    blocked = asyncio.Semaphore(0)
+
+    async def get_blocked_semaphore():
+        return blocked
+
+    monkeypatch.setattr(issue_worker_module, "_get_issue_semaphore", get_blocked_semaphore)
+    monkeypatch.setattr(
+        issue_worker_module,
+        "get_settings",
+        lambda: SimpleNamespace(review_timeout_seconds=60),
+    )
+
+    task = asyncio.create_task(worker.process_issue_analysis(_issue_info()))
+    task_key = "owner/repo#7"
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if task_key in worker._task_handles:
+            break
+
+    assert not task.done()
+    assert await worker.cancel_task(task_key) is True
+    assert task.done()
+    assert task.cancelled()
+    execution.finish.assert_awaited_once_with("cancelled", error_message=None)
+    assert worker._cancel_events == {}
+    assert await worker.cancel_task(task_key) is False
+
+
+@pytest.mark.asyncio
+async def test_admission_rejection_unregisters_pre_registered_issue_task(monkeypatch):
+    worker = IssueWorker.__new__(IssueWorker)
+    worker._cancel_events = {}
+    worker._task_handles = {}
+    worker._task_analysis_records = {}
+
+    def reject_registration(_task, _source):
+        raise DatabaseResetRuntimeAdmissionClosed("reset is closing")
+
+    monkeypatch.setattr(issue_worker_module, "ensure_background_admission", lambda _: None)
+    monkeypatch.setattr(issue_worker_module, "register_background_task", reject_registration)
+    monkeypatch.setattr(issue_worker_module, "get_issue_worker", lambda: worker)
+    monkeypatch.setattr(
+        issue_worker_module,
+        "get_settings",
+        lambda: SimpleNamespace(review_timeout_seconds=60),
+    )
+
+    with pytest.raises(DatabaseResetRuntimeAdmissionClosed):
+        await issue_worker_module.submit_issue_analysis_task(_issue_info())
+
+    assert worker._cancel_events == {}
+    assert worker._task_handles == {}
+    assert worker._task_analysis_records == {}
+
+
+@pytest.mark.asyncio
+async def test_save_result_uses_exact_analysis_id_for_concurrent_same_issue_tasks():
+    service = IssueService()
+    records = [
+        SimpleNamespace(id=101, status="analyzing", issue_state="open"),
+        SimpleNamespace(id=202, status="analyzing", issue_state="open"),
+    ]
+    sessions = [_RecordingSession(record) for record in records]
+
+    for record, session in zip(records, sessions):
+        result = await service.save_analysis_result(
+            {"summary": f"result-{record.id}"},
+            _issue_info(),
+            session,
+            analysis_id=record.id,
+        )
+        assert result is record
+        assert len(session.updates) == 1
+        compiled = session.updates[0].compile()
+        assert compiled.params["id_1"] == record.id
+
+    assert [session.updates[0].compile().params["id_1"] for session in sessions] == [
+        101,
+        202,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_short_repo_compatibility_query_is_owner_scoped():
+    record = SimpleNamespace(id=303, status="analyzing", issue_state="open")
+    session = _RecordingSession(record)
+
+    await IssueService().save_analysis_result(
+        {"summary": "owner-a result"},
+        _issue_info(owner="owner-a"),
+        session,
+    )
+
+    assert len(session.selects) == 1
+    compiled = session.selects[0].compile()
+    assert "repo_owner" in str(session.selects[0])
+    assert "owner-a" in compiled.params.values()
+
+
+@pytest.mark.asyncio
+async def test_save_rowcount_zero_converges_worker_to_cancelled(monkeypatch):
+    execution = SimpleNamespace(
+        merged=False,
+        finish=AsyncMock(),
+        publication_coordinator=None,
+        invocation_context=None,
+        observer=None,
+    )
+    integration = SimpleNamespace(
+        admit_issue=AsyncMock(return_value=SimpleNamespace(session_id=1, trigger_id=2)),
+        start_execution=AsyncMock(return_value=execution),
+    )
+    worker = IssueWorker.__new__(IssueWorker)
+    worker.activity_integration = integration
+    worker.github_app = SimpleNamespace(get_repo_client=lambda *_args: None)
+    worker.analyzer = SimpleNamespace(
+        api_client=None,
+        analyze_issue=AsyncMock(return_value={"summary": "stale"}),
+    )
+    worker._background_tasks = set()
+
+    record_holder = {}
+
+    class WorkerSession(_RecordingSession):
+        async def execute(self, statement):
+            if getattr(statement, "is_update", False):
+                self.updates.append(statement)
+                return _Result(rowcount=1)
+            if "issue_analyses.id" in str(statement):
+                return _Result(record_holder.get("record"))
+            return _Result(None)
+
+        def add(self, record):
+            record.id = 404
+            record_holder["record"] = record
+
+        async def scalar(self, _statement):
+            return 0
+
+    session = WorkerSession()
+    monkeypatch.setattr(issue_worker_module, "async_session", lambda: _SessionContext(session))
+    monkeypatch.setattr(
+        issue_worker_module,
+        "_get_issue_semaphore",
+        lambda: _ready_semaphore(),
+    )
+    save_result = AsyncMock(return_value=None)
+    monkeypatch.setattr(issue_worker_module.issue_service, "save_analysis_result", save_result)
+
+    async def _ready_semaphore():
+        return asyncio.Semaphore(1)
+
+    task_id = await worker.process_issue_analysis(_issue_info())
+
+    record = record_holder["record"]
+    assert task_id == "issue-task"
+    assert record.status == issue_worker_module.IssueAnalysisStatus.CANCELLED.value
+    assert save_result.await_args.kwargs["analysis_id"] == 404
+    execution.finish.assert_awaited_once_with("cancelled", error_message=None)
+    assert worker._cancel_events == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", ["completed", "failed"])
+async def test_terminal_analysis_does_not_emit_cancelled_or_change_execution(
+    monkeypatch, terminal_status
+):
+    """A stale cancellation must preserve an already terminal analysis row."""
+    execution = SimpleNamespace(
+        merged=False,
+        finish=AsyncMock(),
+        publication_coordinator=None,
+        invocation_context=None,
+        observer=None,
+    )
+    integration = SimpleNamespace(
+        admit_issue=AsyncMock(return_value=SimpleNamespace(session_id=1, trigger_id=2)),
+        start_execution=AsyncMock(return_value=execution),
+    )
+    worker = IssueWorker.__new__(IssueWorker)
+    worker.activity_integration = integration
+    worker.github_app = SimpleNamespace(get_repo_client=lambda *_args: None)
+    worker.analyzer = SimpleNamespace(
+        api_client=None,
+        analyze_issue=AsyncMock(side_effect=ReviewCancelledError()),
+    )
+    worker._background_tasks = set()
+
+    record_holder = {}
+
+    class TerminalSession(_RecordingSession):
+        def add(self, record):
+            record.id = 505
+            record_holder["record"] = record
+
+        async def execute(self, statement):
+            if getattr(statement, "is_update", False):
+                self.updates.append(statement)
+                return _Result(rowcount=1)
+            self.selects.append(statement)
+            return _Result(record_holder.get("record"))
+
+        async def scalar(self, _statement):
+            return 0
+
+        async def commit(self):
+            self.commits += 1
+            # Simulate a sibling completing/failing this exact row after the
+            # worker's ANALYZING transition but before cancellation cleanup.
+            if self.commits >= 2:
+                record_holder["record"].status = terminal_status
+
+    session = TerminalSession()
+    monkeypatch.setattr(issue_worker_module, "async_session", lambda: _SessionContext(session))
+    monkeypatch.setattr(
+        issue_worker_module,
+        "_get_issue_semaphore",
+        lambda: _ready_semaphore(),
+    )
+    monkeypatch.setattr(
+        issue_worker_module,
+        "get_settings",
+        lambda: SimpleNamespace(review_timeout_seconds=60),
+    )
+
+    async def _ready_semaphore():
+        return asyncio.Semaphore(1)
+
+    publish_event = AsyncMock()
+    monkeypatch.setattr("backend.webui.sse.publish_event", publish_event)
+
+    task_id = await worker.process_issue_analysis(_issue_info())
+
+    assert task_id == "issue-task"
+    assert record_holder["record"].status == terminal_status
+    execution.finish.assert_awaited_once_with(terminal_status, error_message=None)
+    assert all(
+        call.args[1].get("status") != "cancelled"
+        for call in publish_event.await_args_list
+    )
+    assert session.updates == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", ["completed", "failed"])
+async def test_task_cancel_refreshes_terminal_execution_status(
+    monkeypatch, terminal_status
+):
+    """Forced cancellation refreshes the exact row before finishing execution."""
+    execution = SimpleNamespace(
+        merged=False,
+        finish=AsyncMock(),
+        publication_coordinator=None,
+        invocation_context=None,
+        observer=None,
+    )
+    integration = SimpleNamespace(
+        admit_issue=AsyncMock(return_value=SimpleNamespace(session_id=1, trigger_id=2)),
+        start_execution=AsyncMock(return_value=execution),
+    )
+    worker = IssueWorker.__new__(IssueWorker)
+    worker.activity_integration = integration
+    worker.github_app = SimpleNamespace(get_repo_client=lambda *_args: None)
+    analysis_started = asyncio.Event()
+    never = asyncio.Event()
+
+    async def wait_for_cancellation(**_kwargs):
+        analysis_started.set()
+        await never.wait()
+
+    worker.analyzer = SimpleNamespace(
+        api_client=None,
+        analyze_issue=wait_for_cancellation,
+    )
+    worker._background_tasks = set()
+
+    record_holder = {}
+
+    class TerminalSession(_RecordingSession):
+        def add(self, record):
+            record.id = 808
+            record_holder["record"] = record
+
+        async def execute(self, statement):
+            if getattr(statement, "is_update", False):
+                self.updates.append(statement)
+                return _Result(rowcount=1)
+            self.selects.append(statement)
+            return _Result(record_holder.get("record"))
+
+        async def scalar(self, _statement):
+            return 0
+
+        async def commit(self):
+            self.commits += 1
+            # Simulate an independent transaction winning after ANALYZING was
+            # committed but before the worker receives task.cancel().
+            if self.commits >= 2:
+                record_holder["record"].status = terminal_status
+
+    sessions = []
+
+    def session_factory():
+        session = TerminalSession()
+        sessions.append(session)
+        return _SessionContext(session)
+
+    monkeypatch.setattr(issue_worker_module, "async_session", session_factory)
+    monkeypatch.setattr(
+        issue_worker_module,
+        "_get_issue_semaphore",
+        lambda: _ready_semaphore(),
+    )
+    monkeypatch.setattr(
+        issue_worker_module,
+        "get_settings",
+        lambda: SimpleNamespace(review_timeout_seconds=60),
+    )
+    publish_event = AsyncMock()
+    monkeypatch.setattr("backend.webui.sse.publish_event", publish_event)
+
+    async def _ready_semaphore():
+        return asyncio.Semaphore(1)
+
+    task = asyncio.create_task(worker.process_issue_analysis(_issue_info()))
+    await asyncio.wait_for(analysis_started.wait(), timeout=1)
+
+    assert await worker.cancel_task("owner/repo#7") is True
+    assert task.done()
+    assert task.cancelled()
+    assert record_holder["record"].status == terminal_status
+    execution.finish.assert_awaited_once_with(terminal_status, error_message=None)
+    assert all(
+        call.args[1].get("status") != "cancelled"
+        for call in publish_event.await_args_list
+    )
+    assert all(not session.updates for session in sessions)
+    assert worker._cancel_events == {}
+
+
+@pytest.mark.asyncio
+async def test_active_and_already_cancelled_analysis_emit_cancelled_once(monkeypatch):
+    """Active and close-pre-cancelled rows both converge without duplicate SSE."""
+    worker = IssueWorker.__new__(IssueWorker)
+    worker._cancelled_analysis_notifications = set()
+    publish_event = AsyncMock()
+    monkeypatch.setattr("backend.webui.sse.publish_event", publish_event)
+    activity = AsyncMock()
+    worker._log_activity = activity
+
+    active_record = SimpleNamespace(id=606, status="analyzing", issue_state="open")
+    active_session = _RecordingSession(active_record, update_rowcount=1)
+    first = await worker._converge_cancelled_analysis(
+        active_session,
+        analysis_id=606,
+        issue_info=_issue_info(),
+        reason="cancelled",
+    )
+    second = await worker._converge_cancelled_analysis(
+        active_session,
+        analysis_id=606,
+        issue_info=_issue_info(),
+        reason="cancelled again",
+    )
+
+    assert first == (active_record, "cancelled")
+    assert second == (active_record, "cancelled")
+    assert active_record.status == "cancelled"
+    assert publish_event.await_count == 1
+    activity.assert_awaited_once_with(606, "cancelled", {"message": "cancelled"})
+
+    publish_event.reset_mock()
+    activity.reset_mock()
+    already_cancelled = SimpleNamespace(id=707, status="cancelled", issue_state="closed")
+    cancelled_session = _RecordingSession(already_cancelled)
+    await worker._converge_cancelled_analysis(
+        cancelled_session,
+        analysis_id=707,
+        issue_info=_issue_info(),
+        reason="close webhook already cancelled",
+    )
+    await worker._converge_cancelled_analysis(
+        cancelled_session,
+        analysis_id=707,
+        issue_info=_issue_info(),
+        reason="duplicate close webhook",
+    )
+
+    assert publish_event.await_count == 1
+    activity.assert_not_awaited()

--- a/tests/test_issue_cancelled_ui.py
+++ b/tests/test_issue_cancelled_ui.py
@@ -1,0 +1,129 @@
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from backend.webui.i18n import make_translation_func
+
+TEMPLATE_ROOT = Path(__file__).resolve().parents[1] / "backend" / "webui" / "templates"
+
+
+@pytest.fixture(scope="module")
+def template_env():
+    env = Environment(loader=FileSystemLoader(str(TEMPLATE_ROOT)), autoescape=True)
+    env.globals["_"] = make_translation_func("en")
+    env.globals["settings"] = SimpleNamespace(payment_enabled=False)
+    return env
+
+
+def _analysis(status):
+    return SimpleNamespace(
+        id=1,
+        issue_number=536,
+        title="Status rendering",
+        repo_owner="owner",
+        repo_name="repo",
+        author=None,
+        created_at=None,
+        category=None,
+        priority=None,
+        status=status,
+        summary=None,
+        feasibility=None,
+        prompt_tokens=0,
+        completion_tokens=0,
+        estimated_cost=0,
+        duplicate_of=None,
+        error_message=None,
+    )
+
+
+def _render_issue_list(template_env, status):
+    analysis = _analysis(status)
+    return template_env.get_template("components/issue_list_fragment.html").render(
+        analyses=[analysis],
+        search="",
+        repo_name="",
+        category="",
+        priority="",
+        status="",
+        total=1,
+        page=1,
+        total_pages=1,
+    )
+
+
+def _render_detail(template_env, status):
+    return template_env.get_template("issue_detail.html").render(
+        analysis=_analysis(status),
+        suggested_labels=[],
+        suggested_assignees=[],
+        related_prs=[],
+        current_user={"role": "admin", "sub": "tester"},
+        user_prefs={"language": "en"},
+        lang="en",
+        app_timezone="UTC",
+        csrf_token="",
+    )
+
+
+def _render_detail_fragment(template_env, status):
+    return template_env.get_template(
+        "components/issue_detail_fragment.html"
+    ).render(analysis=_analysis(status))
+
+
+def _status_block(html, end_marker):
+    block = html.split("<!-- 状态 -->", 1)[1].split(end_marker, 1)[0]
+    return re.sub(r"<[^>]+>", " ", block)
+
+
+def _detail_status_block(html):
+    block = html.split("<!-- 标题区 -->", 1)[1].split("<!-- AI 分析结果 -->", 1)[0]
+    return re.sub(r"<[^>]+>", " ", block)
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    (
+        ("pending", "Pending"),
+        ("cancelled", "Cancelled"),
+        ("awaiting_review", "awaiting_review"),
+        (None, "Unknown"),
+    ),
+)
+def test_issue_statuses_render_pending_cancelled_and_unknown_distinctly(
+    template_env, status, expected
+):
+    list_html = _render_issue_list(template_env, status)
+    detail_html = _render_detail(template_env, status)
+    fragment_html = _render_detail_fragment(template_env, status)
+
+    list_status = _status_block(list_html, "<!-- Issue 信息 -->")
+    detail_status = _detail_status_block(detail_html)
+    fragment_status = re.search(
+        r'<span class="px-2\.5 py-1 rounded-full text-xs font-medium[^>]*>(.*?)</span>',
+        fragment_html,
+        re.DOTALL,
+    )
+
+    assert fragment_status is not None
+    fragment_text = re.sub(r"<[^>]+>", " ", fragment_status.group(1))
+    for rendered_status in (list_status, detail_status, fragment_text):
+        assert expected in rendered_status
+        if status == "awaiting_review":
+            assert "Pending" not in rendered_status
+
+
+def test_issue_filters_keep_cancelled_option_and_selection(template_env):
+    html = template_env.get_template("components/issue_filters.html").render(
+        search="",
+        category="",
+        priority="",
+        status="cancelled",
+    )
+
+    assert re.search(r'<option value="cancelled"\s+selected>', html)
+    assert "Cancelled" in html

--- a/tests/test_issue_webhook_cancellation.py
+++ b/tests/test_issue_webhook_cancellation.py
@@ -1,0 +1,372 @@
+"""Focused lifecycle tests for Issue webhook cancellation (Issue #536)."""
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _issue_payload(action: str) -> dict:
+    return {
+        "action": action,
+        "issue": {
+            "number": 536,
+            "title": "Lifecycle test",
+            "body": "Issue body",
+            "state": "closed" if action == "closed" else "open",
+            "user": {"login": "contributor"},
+        },
+        "repository": {
+            "name": "sakura-ai-test",
+            "full_name": "owner/sakura-ai-test",
+            "owner": {"login": "owner"},
+        },
+    }
+
+
+class _SessionContext:
+    def __init__(self, session=None):
+        self.session = session or object()
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+@pytest.fixture
+def webhook_dependencies(monkeypatch):
+    """Install side-effect-free worker/service/session dependencies."""
+    from backend.api import webhook
+    from backend.services.issue_service import issue_service
+    from backend.workers import issue_worker
+
+    events = []
+
+    async def cancel_task(key):
+        events.append(("cancel", key))
+        return True
+
+    worker = SimpleNamespace(cancel_task=cancel_task)
+    monkeypatch.setattr(issue_worker, "get_issue_worker", lambda: worker)
+    monkeypatch.setattr(
+        webhook,
+        "settings",
+        SimpleNamespace(bot_username=None, enable_semantic_issue_linking=False),
+    )
+    monkeypatch.setattr(webhook, "get_async_session", lambda: _SessionContext())
+    return webhook, issue_service, events
+
+
+@pytest.mark.asyncio
+async def test_closed_cancels_before_persisting_lifecycle_state(
+    monkeypatch, webhook_dependencies
+):
+    webhook, issue_service, events = webhook_dependencies
+
+    async def mark_closed(owner, repo, number, db):
+        events.append(("close", owner, repo, number))
+        return {"cancelled": 1, "state_updated": 1}
+
+    monkeypatch.setattr(issue_service, "mark_issue_closed", mark_closed)
+
+    response = await webhook.handle_issue_event(_issue_payload("closed"))
+
+    assert response.status_code == 200
+    assert json.loads(response.body.decode())["action"] == "closed"
+    assert events == [
+        ("cancel", "owner/sakura-ai-test#536"),
+        ("close", "owner", "sakura-ai-test", 536),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_deleted_cancels_before_idempotent_cleanup_and_repeats_safely(
+    monkeypatch, webhook_dependencies
+):
+    webhook, issue_service, events = webhook_dependencies
+
+    from backend.workers import issue_worker
+
+    async def cancel_task(key):
+        events.append(("cancel", key))
+        return False
+
+    monkeypatch.setattr(
+        issue_worker,
+        "get_issue_worker",
+        lambda: SimpleNamespace(cancel_task=cancel_task),
+    )
+
+    async def delete_issue(owner, repo, number, db):
+        events.append(("delete", owner, repo, number))
+        return {"analysis_deleted": 1}
+
+    monkeypatch.setattr(issue_service, "delete_issue_data", delete_issue)
+
+    for _ in range(2):
+        response = await webhook.handle_issue_event(_issue_payload("deleted"))
+        assert response.status_code == 200
+
+    assert events == [
+        ("cancel", "owner/sakura-ai-test#536"),
+        ("delete", "owner", "sakura-ai-test", 536),
+        ("cancel", "owner/sakura-ai-test#536"),
+        ("delete", "owner", "sakura-ai-test", 536),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_deleted_waits_for_cancellation_to_converge_before_cleanup(
+    monkeypatch, webhook_dependencies
+):
+    webhook, issue_service, events = webhook_dependencies
+
+    from backend.workers import issue_worker
+
+    cancellation_started = asyncio.Event()
+    cancellation_release = asyncio.Event()
+
+    async def cancel_task(key):
+        events.append(("cancel-start", key))
+        cancellation_started.set()
+        await cancellation_release.wait()
+        events.append(("cancel-done", key))
+        return True
+
+    monkeypatch.setattr(
+        issue_worker,
+        "get_issue_worker",
+        lambda: SimpleNamespace(cancel_task=cancel_task),
+    )
+
+    async def delete_issue(owner, repo, number, db):
+        events.append(("delete", owner, repo, number))
+        return {"analysis_deleted": 1}
+
+    monkeypatch.setattr(issue_service, "delete_issue_data", delete_issue)
+
+    request = asyncio.create_task(webhook.handle_issue_event(_issue_payload("deleted")))
+    await asyncio.wait_for(cancellation_started.wait(), timeout=1)
+    await asyncio.sleep(0)
+    assert not any(event[0] == "delete" for event in events)
+
+    cancellation_release.set()
+    response = await asyncio.wait_for(request, timeout=1)
+
+    assert response.status_code == 200
+    assert events == [
+        ("cancel-start", "owner/sakura-ai-test#536"),
+        ("cancel-done", "owner/sakura-ai-test#536"),
+        ("delete", "owner", "sakura-ai-test", 536),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_missing_worker_is_idempotent_before_deleted_cleanup(
+    monkeypatch, webhook_dependencies
+):
+    webhook, issue_service, events = webhook_dependencies
+
+    from backend.workers import issue_worker
+
+    monkeypatch.setattr(issue_worker, "get_issue_worker", lambda: None)
+
+    async def delete_issue(owner, repo, number, db):
+        events.append(("delete", owner, repo, number))
+        return {"analysis_deleted": 0}
+
+    monkeypatch.setattr(issue_service, "delete_issue_data", delete_issue)
+
+    response = await webhook.handle_issue_event(_issue_payload("deleted"))
+
+    assert response.status_code == 200
+    assert events == [("delete", "owner", "sakura-ai-test", 536)]
+
+
+@pytest.mark.asyncio
+async def test_cancel_failure_preserves_webhook_retry_and_skips_deleted_cleanup(
+    monkeypatch, webhook_dependencies
+):
+    webhook, issue_service, events = webhook_dependencies
+
+    from backend.workers import issue_worker
+
+    async def cancel_task(key):
+        events.append(("cancel", key))
+        raise RuntimeError("worker cancellation failed")
+
+    monkeypatch.setattr(
+        issue_worker,
+        "get_issue_worker",
+        lambda: SimpleNamespace(cancel_task=cancel_task),
+    )
+
+    async def delete_issue(owner, repo, number, db):
+        pytest.fail("cleanup must not run after cancellation failure")
+
+    monkeypatch.setattr(issue_service, "delete_issue_data", delete_issue)
+
+    response = await webhook.handle_issue_event(_issue_payload("deleted"))
+
+    assert response.status_code == 500
+    assert json.loads(response.body.decode()) == {
+        "status": "error",
+        "message": "内部服务错误",
+    }
+    assert events == [("cancel", "owner/sakura-ai-test#536")]
+
+
+@pytest.mark.asyncio
+async def test_cancel_failure_propagates_from_lifecycle_helper(
+    monkeypatch, webhook_dependencies
+):
+    webhook, _issue_service, events = webhook_dependencies
+
+    from backend.workers import issue_worker
+
+    async def cancel_task(key):
+        events.append(("cancel", key))
+        raise RuntimeError("worker cancellation failed")
+
+    monkeypatch.setattr(
+        issue_worker,
+        "get_issue_worker",
+        lambda: SimpleNamespace(cancel_task=cancel_task),
+    )
+
+    with pytest.raises(RuntimeError, match="worker cancellation failed"):
+        await webhook._cancel_issue_analysis_task(
+            {
+                "repo_owner": "owner",
+                "repo_name": "sakura-ai-test",
+                "issue_number": 536,
+            }
+        )
+
+    assert events == [("cancel", "owner/sakura-ai-test#536")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["closed", "deleted"])
+async def test_pull_request_issue_lifecycle_is_ignored(
+    monkeypatch, webhook_dependencies, action
+):
+    webhook, issue_service, events = webhook_dependencies
+    payload = _issue_payload(action)
+    payload["issue"]["pull_request"] = {
+        "url": "https://api.github.com/repos/owner/sakura-ai-test/pulls/536"
+    }
+
+    async def unexpected_close(*args):
+        pytest.fail("PR issues webhook must not mark an IssueAnalysis closed")
+
+    async def unexpected_delete(*args):
+        pytest.fail("PR issues webhook must not delete IssueAnalysis")
+
+    monkeypatch.setattr(issue_service, "mark_issue_closed", unexpected_close)
+    monkeypatch.setattr(issue_service, "delete_issue_data", unexpected_delete)
+
+    response = await webhook.handle_issue_event(payload)
+
+    assert response.status_code == 200
+    assert json.loads(response.body.decode()) == {
+        "status": "ignored",
+        "action": action,
+        "reason": "pull request issue event",
+    }
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_close_transition_keeps_completed_and_cancels_active_rows():
+    from backend.services.issue_service import IssueService
+
+    active = SimpleNamespace(status="analyzing", issue_state="open")
+    completed = SimpleNamespace(status="completed", issue_state="open")
+
+    class LifecycleSession:
+        def __init__(self):
+            self.calls = 0
+
+        async def execute(self, statement):
+            self.calls += 1
+            if self.calls == 1:
+                active.status = "cancelled"
+                active.issue_state = "closed"
+                return SimpleNamespace(rowcount=1)
+            completed.issue_state = "closed"
+            return SimpleNamespace(rowcount=2)
+
+        async def commit(self):
+            return None
+
+    result = await IssueService().mark_issue_closed(
+        "owner", "sakura-ai-test", 536, LifecycleSession()
+    )
+
+    assert result == {"cancelled": 1, "state_updated": 2}
+    assert active.status == "cancelled"
+    assert completed.status == "completed"
+    assert active.issue_state == completed.issue_state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_save_result_drops_stale_worker_after_close_wins_race():
+    from backend.services.issue_service import IssueService
+
+    record = SimpleNamespace(id=1, status="cancelled", issue_state="closed")
+
+    class RaceSession:
+        def __init__(self):
+            self.calls = 0
+            self.commits = 0
+
+        async def execute(self, statement):
+            self.calls += 1
+            if self.calls == 1:
+                return SimpleNamespace(scalar_one_or_none=lambda: record)
+            # Simulate the conditional UPDATE observing the close commit.
+            return SimpleNamespace(rowcount=0)
+
+        async def commit(self):
+            self.commits += 1
+
+    result = await IssueService().save_analysis_result(
+        {"summary": "stale result"},
+        {
+            "repo_owner": "owner",
+            "repo_name": "sakura-ai-test",
+            "repo_full_name": "owner/sakura-ai-test",
+            "issue_number": 536,
+        },
+        RaceSession(),
+    )
+
+    assert result is None
+    assert record.status == "cancelled"
+    assert record.issue_state == "closed"
+
+
+def test_issue_templates_render_cancelled_status_and_filter():
+    template_root = Path(__file__).resolve().parents[1] / "backend" / "webui" / "templates"
+    detail = (template_root / "issue_detail.html").read_text(encoding="utf-8")
+    fragment = (
+        template_root / "components" / "issue_detail_fragment.html"
+    ).read_text(encoding="utf-8")
+    listing = (
+        template_root / "components" / "issue_list_fragment.html"
+    ).read_text(encoding="utf-8")
+    filters = (
+        template_root / "components" / "issue_filters.html"
+    ).read_text(encoding="utf-8")
+
+    assert detail.count("analysis.status == 'cancelled'") == 1
+    assert "{{ _('issue.cancelled_status') }}" in detail
+    assert "analysis.status == 'cancelled'" in fragment
+    assert "{{ _('issue.cancelled_status') }}" in fragment
+    assert "a.status == 'cancelled'" in listing
+    assert '<option value="cancelled"' in filters

--- a/tests/test_issue_webhook_cancellation.py
+++ b/tests/test_issue_webhook_cancellation.py
@@ -315,6 +315,172 @@ async def test_close_transition_keeps_completed_and_cancels_active_rows():
 
 
 @pytest.mark.asyncio
+async def test_reopen_transition_restores_owner_scoped_short_and_full_rows():
+    from sqlalchemy.dialects import sqlite
+
+    from backend.services.issue_service import IssueService
+
+    owner_short = SimpleNamespace(
+        repo_owner="owner",
+        repo_name="sakura-ai-test",
+        issue_state="closed",
+        status="cancelled",
+    )
+    owner_full = SimpleNamespace(
+        repo_owner="owner",
+        repo_name="owner/sakura-ai-test",
+        issue_state="closed",
+        status="completed",
+    )
+    other_owner = SimpleNamespace(
+        repo_owner="other-owner",
+        repo_name="sakura-ai-test",
+        issue_state="closed",
+        status="cancelled",
+    )
+
+    class LifecycleSession:
+        def __init__(self):
+            self.statement = None
+            self.commits = 0
+
+        async def execute(self, statement):
+            self.statement = statement
+            for record in (owner_short, owner_full, other_owner):
+                if record.repo_owner == "owner" and record.repo_name in {
+                    "sakura-ai-test",
+                    "owner/sakura-ai-test",
+                }:
+                    record.issue_state = "open"
+            return SimpleNamespace(rowcount=2)
+
+        async def commit(self):
+            self.commits += 1
+
+    session = LifecycleSession()
+    result = await IssueService().mark_issue_reopened(
+        "owner", "sakura-ai-test", 536, session
+    )
+
+    compiled = str(
+        session.statement.compile(
+            dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert "repo_owner = 'owner'" in compiled
+    assert "'sakura-ai-test'" in compiled
+    assert "'owner/sakura-ai-test'" in compiled
+    assert result == {"state_updated": 2}
+    assert owner_short.issue_state == owner_full.issue_state == "open"
+    assert other_owner.issue_state == "closed"
+    assert owner_short.status == "cancelled"
+    assert owner_full.status == "completed"
+    assert session.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_reopen_transition_is_idempotent_when_no_records_match():
+    from backend.services.issue_service import IssueService
+
+    class EmptySession:
+        def __init__(self):
+            self.commits = 0
+
+        async def execute(self, _statement):
+            return SimpleNamespace(rowcount=0)
+
+        async def commit(self):
+            self.commits += 1
+
+    session = EmptySession()
+    result = await IssueService().mark_issue_reopened(
+        "owner", "missing-repo", 536, session
+    )
+
+    assert result == {"state_updated": 0}
+    assert session.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_reopened_syncs_short_name_row_when_semantic_linking_disabled(
+    monkeypatch, webhook_dependencies
+):
+    webhook, issue_service, events = webhook_dependencies
+    row = SimpleNamespace(issue_state="closed", status="cancelled")
+
+    async def mark_reopened(owner, repo, number, db):
+        events.append(("reopen", owner, repo, number, db))
+        row.issue_state = "open"
+        return {"state_updated": 1}
+
+    async def disabled(_name):
+        return False
+
+    monkeypatch.setattr(issue_service, "mark_issue_reopened", mark_reopened)
+    monkeypatch.setattr(webhook, "get_dynamic_config", disabled)
+
+    response = await webhook.handle_issue_event(_issue_payload("reopened"))
+
+    assert response.status_code == 200
+    assert json.loads(response.body.decode()) == {
+        "status": "skipped",
+        "reason": "feature disabled",
+    }
+    assert row.issue_state == "open"
+    assert row.status == "cancelled"
+    assert len(events) == 1
+    assert events[0][:4] == ("reopen", "owner", "sakura-ai-test", 536)
+
+
+@pytest.mark.asyncio
+async def test_reopened_syncs_db_after_semantic_vector_reopen(
+    monkeypatch, webhook_dependencies
+):
+    webhook, issue_service, events = webhook_dependencies
+    webhook.settings.enable_semantic_issue_linking = True
+    row_states = {
+        ("owner", "sakura-ai-test"): "closed",
+        ("owner", "owner/sakura-ai-test"): "closed",
+        ("other-owner", "sakura-ai-test"): "closed",
+    }
+
+    class FakeEmbeddingService:
+        async def upsert_issue(self, owner, repo, number, **kwargs):
+            events.append(("vector-reopen", owner, repo, number, kwargs))
+
+    async def mark_reopened(owner, repo, number, _db):
+        events.append(("reopen", owner, repo, number))
+        for identity in list(row_states):
+            if identity[0] == owner and identity[1] in {
+                repo,
+                f"{owner}/{repo}",
+            }:
+                row_states[identity] = "open"
+        return {"state_updated": 2}
+
+    async def disabled(_name):
+        return False
+
+    from backend.services import issue_embedding_service
+
+    monkeypatch.setattr(
+        issue_embedding_service, "IssueEmbeddingService", FakeEmbeddingService
+    )
+    monkeypatch.setattr(issue_service, "mark_issue_reopened", mark_reopened)
+    monkeypatch.setattr(webhook, "get_dynamic_config", disabled)
+
+    response = await webhook.handle_issue_event(_issue_payload("reopened"))
+
+    assert response.status_code == 200
+    assert row_states == {
+        ("owner", "sakura-ai-test"): "open",
+        ("owner", "owner/sakura-ai-test"): "open",
+        ("other-owner", "sakura-ai-test"): "closed",
+    }
+    assert [event[0] for event in events] == ["vector-reopen", "reopen"]
+
+
+@pytest.mark.asyncio
 async def test_save_result_drops_stale_worker_after_close_wins_race():
     from backend.services.issue_service import IssueService
 

--- a/tests/test_issue_worker_cancellation.py
+++ b/tests/test_issue_worker_cancellation.py
@@ -6,8 +6,192 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from backend.core.ai_protocol.errors import ReviewCancelledError
 from backend.workers import issue_worker as issue_worker_module
 from backend.workers.issue_worker import IssueWorker
+
+
+@pytest.mark.asyncio
+async def test_issue_cancel_registry_is_per_task_and_repeated_cancel_is_safe():
+    worker = IssueWorker.__new__(IssueWorker)
+    worker._cancel_events = {}
+    task_key = "owner/repo#7"
+
+    first = worker._register_task(task_key, "task-1")
+    second = worker._register_task(task_key, "task-2")
+
+    assert worker._cancel_events == {
+        task_key: {"task-1": first, "task-2": second}
+    }
+    assert await worker.cancel_task(task_key) is True
+    assert first.is_set() and second.is_set()
+    assert await worker.cancel_task(task_key) is False
+
+    worker._unregister_task(task_key, "task-1")
+    assert worker._cancel_events[task_key] == {"task-2": second}
+    worker._unregister_task(task_key, "task-2")
+    assert task_key not in worker._cancel_events
+
+    fresh = worker._register_task(task_key, "task-3")
+    assert fresh is not first
+    assert not fresh.is_set()
+
+
+def test_issue_task_key_supports_full_name_or_owner_and_repo():
+    assert IssueWorker._make_task_key(
+        {"repo_full_name": "owner/repo", "issue_number": 7}
+    ) == "owner/repo#7"
+    assert IssueWorker._make_task_key(
+        {"repo_owner": "owner", "repo_name": "repo", "issue_number": 7}
+    ) == "owner/repo#7"
+
+
+@pytest.mark.asyncio
+async def test_issue_submission_registers_before_coroutine_runs_and_cleans_own_event(
+    monkeypatch,
+):
+    worker = IssueWorker.__new__(IssueWorker)
+    worker._cancel_events = {}
+    worker._background_tasks = set()
+    release = asyncio.Event()
+    started = asyncio.Event()
+    observed = {}
+
+    async def _run_issue_analysis(
+        issue_info,
+        *,
+        deadline,
+        cancel_event,
+        task_id,
+    ):
+        observed["event"] = cancel_event
+        started.set()
+        await release.wait()
+        return task_id
+
+    worker._run_issue_analysis = _run_issue_analysis
+    monkeypatch.setattr(issue_worker_module, "get_issue_worker", lambda: worker)
+    monkeypatch.setattr(issue_worker_module, "ensure_background_admission", lambda _: None)
+    monkeypatch.setattr(issue_worker_module, "register_background_task", lambda *_: None)
+    monkeypatch.setattr(
+        issue_worker_module,
+        "get_settings",
+        lambda: SimpleNamespace(review_timeout_seconds=60),
+    )
+
+    issue_info = {
+        "repo_owner": "owner",
+        "repo_name": "repo",
+        "issue_number": 7,
+    }
+    task_id = await issue_worker_module.submit_issue_analysis_task(issue_info)
+    task_key = "owner/repo#7"
+    registered = worker._cancel_events[task_key][task_id]
+    assert not started.is_set()
+
+    assert await worker.cancel_task(task_key) is True
+    assert registered.is_set()
+    await asyncio.sleep(0)
+
+    # The task handle is cancelled before its coroutine gets a chance to run;
+    # this is required for lifecycle webhooks to avoid post-delete work.
+    assert not started.is_set()
+    assert task_key not in worker._cancel_events
+
+
+@pytest.mark.asyncio
+async def test_review_cancelled_error_marks_active_issue_cancelled_and_skips_save(
+    monkeypatch,
+):
+    execution = SimpleNamespace(
+        merged=False,
+        finish=AsyncMock(),
+        publication_coordinator=None,
+        invocation_context=None,
+        observer=None,
+    )
+    integration = SimpleNamespace(
+        admit_issue=AsyncMock(
+            return_value=SimpleNamespace(session_id=1, trigger_id=2)
+        ),
+        start_execution=AsyncMock(return_value=execution),
+    )
+    record = SimpleNamespace(
+        id=11,
+        status=issue_worker_module.IssueAnalysisStatus.ANALYZING.value,
+        error_message=None,
+    )
+
+    class _Result:
+        def scalar_one_or_none(self):
+            return record
+
+    class _Db:
+        def add(self, value):
+            value.id = record.id
+
+        async def scalar(self, _query):
+            return 0
+
+        async def execute(self, _query):
+            return _Result()
+
+        async def commit(self):
+            return None
+
+        async def refresh(self, _value):
+            return None
+
+    class _Session:
+        async def __aenter__(self):
+            return db
+
+        async def __aexit__(self, *_args):
+            return False
+
+    db = _Db()
+    worker = IssueWorker.__new__(IssueWorker)
+    worker.activity_integration = integration
+    worker.github_app = SimpleNamespace(get_repo_client=lambda *_: None)
+    worker.analyzer = SimpleNamespace(
+        api_client=None,
+        analyze_issue=AsyncMock(side_effect=ReviewCancelledError()),
+    )
+    worker._background_tasks = set()
+
+    monkeypatch.setattr(issue_worker_module, "async_session", lambda: _Session())
+    monkeypatch.setattr(
+        issue_worker_module,
+        "get_settings",
+        lambda: SimpleNamespace(review_timeout_seconds=60),
+    )
+    monkeypatch.setattr(
+        issue_worker_module,
+        "_get_issue_semaphore",
+        lambda: _ready_semaphore(),
+    )
+    save_result = AsyncMock()
+    monkeypatch.setattr(issue_worker_module.issue_service, "save_analysis_result", save_result)
+
+    async def _ready_semaphore():
+        return asyncio.Semaphore(1)
+
+    task_id = await worker.process_issue_analysis(
+        {
+            "task_id": "issue-cancelled",
+            "repo_owner": "owner",
+            "repo_name": "repo",
+            "repo_full_name": "owner/repo",
+            "issue_number": 7,
+        }
+    )
+
+    assert task_id == "issue-cancelled"
+    assert record.status == issue_worker_module.IssueAnalysisStatus.CANCELLED.value
+    assert isinstance(record.error_message, str)
+    execution.finish.assert_awaited_once_with("cancelled", error_message=None)
+    save_result.assert_not_awaited()
+    assert worker._cancel_events == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_issue_worker_cancellation.py
+++ b/tests/test_issue_worker_cancellation.py
@@ -1,12 +1,14 @@
 """Issue Worker cancellation and observability cleanup tests."""
 
 import asyncio
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from backend.core.ai_protocol.errors import ReviewCancelledError
+from backend.services.issue_service import IssueService
 from backend.workers import issue_worker as issue_worker_module
 from backend.workers.issue_worker import IssueWorker
 
@@ -35,6 +37,283 @@ async def test_issue_cancel_registry_is_per_task_and_repeated_cancel_is_safe():
     fresh = worker._register_task(task_key, "task-3")
     assert fresh is not first
     assert not fresh.is_set()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_cancel_waits_for_first_cancellation_to_finish():
+    """A duplicate lifecycle event must await an already-cancelling worker."""
+    worker = IssueWorker.__new__(IssueWorker)
+    worker._cancel_events = {}
+    task_key = "owner/repo#7"
+    worker._register_task(task_key, "task-1")
+    cancellation_seen = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_cancelled_worker():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+            await release.wait()
+            raise
+
+    task = asyncio.create_task(_slow_cancelled_worker())
+    worker._bind_task_handle(task_key, "task-1", task)
+
+    first_cancel = asyncio.create_task(worker.cancel_task(task_key))
+    await asyncio.wait_for(cancellation_seen.wait(), timeout=1)
+
+    second_cancel = asyncio.create_task(worker.cancel_task(task_key))
+    await asyncio.sleep(0)
+    assert not second_cancel.done()
+
+    release.set()
+    assert await first_cancel is True
+    assert await second_cancel is False
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_cancel_request_cancellation_still_drains_worker():
+    """Cancelling the first webhook request must not abandon its worker."""
+    worker = IssueWorker.__new__(IssueWorker)
+    worker._cancel_events = {}
+    task_key = "owner/repo#7"
+    worker._register_task(task_key, "task-1")
+    cancellation_seen = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_cancelled_worker():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+            await release.wait()
+            raise
+
+    task = asyncio.create_task(_slow_cancelled_worker())
+    worker._bind_task_handle(task_key, "task-1", task)
+    cancel_request = asyncio.create_task(worker.cancel_task(task_key))
+    await asyncio.wait_for(cancellation_seen.wait(), timeout=1)
+
+    cancel_request.cancel()
+    await asyncio.sleep(0)
+    assert not cancel_request.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await cancel_request
+    assert task.cancelled()
+    assert worker._cancel_events == {}
+
+
+@pytest.mark.asyncio
+async def test_cancel_waits_for_thread_backed_external_write():
+    """Cancellation must wait until an already-started thread write returns."""
+    worker = IssueWorker.__new__(IssueWorker)
+    worker._cancel_events = {}
+    worker._task_external_writes = {}
+    task_key = "owner/repo#7"
+    cancel_event = worker._register_task(task_key, "task-1")
+    write_started = threading.Event()
+    release_write = threading.Event()
+
+    def _blocking_write():
+        write_started.set()
+        release_write.wait(timeout=2)
+        return "written"
+
+    async def _run_write():
+        return await worker._run_external_write(
+            task_key,
+            "task-1",
+            cancel_event,
+            lambda: asyncio.to_thread(_blocking_write),
+        )
+
+    task = asyncio.create_task(_run_write())
+    worker._bind_task_handle(task_key, "task-1", task)
+    await asyncio.wait_for(asyncio.to_thread(write_started.wait), timeout=1)
+
+    cancel_call = asyncio.create_task(worker.cancel_task(task_key))
+    await asyncio.sleep(0)
+    assert not cancel_call.done()
+
+    release_write.set()
+    assert await cancel_call is True
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_labels_checkpoint_blocks_next_mutation_after_cancellation(monkeypatch):
+    """A cancellation after one label write must prevent the next write."""
+    import backend.services.issue_service as issue_service_module
+    import backend.services.label_service as label_service_module
+
+    first_write_started = threading.Event()
+    release_first_write = threading.Event()
+    applied: list[str] = []
+
+    class _GithubApp:
+        def add_labels_to_issue(
+            self, _owner, _repo, _number, labels: list[str]
+        ) -> bool:
+            applied.append(labels[0])
+            if labels == ["first"]:
+                first_write_started.set()
+                release_first_write.wait(timeout=2)
+            return True
+
+    class _LabelService:
+        DEFAULT_LABELS = {}
+
+        async def get_repo_labels(self, _owner, _repo):
+            return {
+                "first": {"color": "000000", "description": ""},
+                "second": {"color": "000000", "description": ""},
+            }
+
+    class _Recommendation:
+        def get_recommendation_settings(self):
+            return {
+                "enabled": True,
+                "confidence_threshold": 0.5,
+                "auto_create": False,
+            }
+
+    monkeypatch.setattr(issue_service_module, "get_label_config", _Recommendation)
+    monkeypatch.setattr(label_service_module, "label_service", _LabelService())
+
+    service = IssueService.__new__(IssueService)
+    service.github_app = _GithubApp()
+    cancel_event = asyncio.Event()
+
+    def checkpoint() -> None:
+        if cancel_event.is_set():
+            raise ReviewCancelledError("Issue 分析已被取消")
+
+    operation = asyncio.create_task(
+        service.apply_suggested_labels(
+            "owner",
+            "repo",
+            7,
+            [
+                {"name": "first", "confidence": 0.9},
+                {"name": "second", "confidence": 0.9},
+            ],
+            db=None,
+            cancellation_checkpoint=checkpoint,
+        )
+    )
+    await asyncio.wait_for(asyncio.to_thread(first_write_started.wait), timeout=1)
+
+    cancel_event.set()
+    release_first_write.set()
+    with pytest.raises(ReviewCancelledError):
+        await operation
+
+    assert applied == ["first"]
+
+
+@pytest.mark.asyncio
+async def test_assignee_checkpoint_after_collaborator_read_skips_mutation(monkeypatch):
+    """Cancellation during collaborator discovery must not add an assignee."""
+    import backend.services.issue_service as issue_service_module
+
+    collaborators_started = threading.Event()
+    release_collaborators = threading.Event()
+    assigned: list[list[str]] = []
+
+    class _GithubApp:
+        def get_repo_collaborators(self, _owner, _repo):
+            collaborators_started.set()
+            release_collaborators.wait(timeout=2)
+            return ["alice"]
+
+        def add_assignees_to_issue(self, _owner, _repo, _number, assignees):
+            assigned.append(assignees)
+            return True
+
+    async def dynamic_config(name: str):
+        return {
+            "issue_assignee_confidence_threshold": 0.5,
+            "issue_auto_assign_max": 2,
+        }[name]
+
+    monkeypatch.setattr(issue_service_module, "get_dynamic_config", dynamic_config)
+
+    service = IssueService.__new__(IssueService)
+    service.github_app = _GithubApp()
+    cancel_event = asyncio.Event()
+
+    def checkpoint() -> None:
+        if cancel_event.is_set():
+            raise ReviewCancelledError("Issue 分析已被取消")
+
+    operation = asyncio.create_task(
+        service.apply_suggested_assignees(
+            "owner",
+            "repo",
+            7,
+            [{"username": "alice", "confidence": 0.9}],
+            cancellation_checkpoint=checkpoint,
+        )
+    )
+    await asyncio.wait_for(asyncio.to_thread(collaborators_started.wait), timeout=1)
+
+    cancel_event.set()
+    release_collaborators.set()
+    with pytest.raises(ReviewCancelledError):
+        await operation
+
+    assert assigned == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_waits_for_observability_admission_and_finishes_bound_execution():
+    """Admission persistence must not strand a queued work unit on cancel."""
+    execution = SimpleNamespace(merged=False, finish=AsyncMock())
+    admission_started = asyncio.Event()
+    release_admission = asyncio.Event()
+
+    async def _start_execution(**_kwargs):
+        admission_started.set()
+        await release_admission.wait()
+        return execution
+
+    integration = SimpleNamespace(
+        admit_issue=AsyncMock(
+            return_value=SimpleNamespace(session_id=1, trigger_id=2)
+        ),
+        start_execution=AsyncMock(side_effect=_start_execution),
+    )
+    worker = IssueWorker.__new__(IssueWorker)
+    worker.activity_integration = integration
+    worker.analyzer = SimpleNamespace(api_client=None)
+    worker._background_tasks = set()
+
+    task = asyncio.create_task(
+        worker.process_issue_analysis(
+            {
+                "task_id": "issue-admission-cancelled",
+                "repo_owner": "owner",
+                "repo_name": "repo",
+                "repo_full_name": "owner/repo",
+                "issue_number": 7,
+            }
+        )
+    )
+    await asyncio.wait_for(admission_started.wait(), timeout=1)
+
+    cancel_call = asyncio.create_task(worker.cancel_task("owner/repo#7"))
+    await asyncio.sleep(0)
+    assert not cancel_call.done()
+    execution.finish.assert_not_awaited()
+
+    release_admission.set()
+    assert await cancel_call is True
+    assert task.cancelled()
+    execution.finish.assert_awaited_once_with("cancelled", error_message=None)
 
 
 def test_issue_task_key_supports_full_name_or_owner_and_repo():


### PR DESCRIPTION
<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI的总结

**变更概览**
本 PR 新增了 Issue 处理的取消功能，大幅增强后台逻辑并补充了全面的测试用例。

**主要改动列表**
- **新增功能**：实现了 Issue 取消机制，重构 `issue_worker` 和 `issue_service` 以支持任务中断与状态同步。
- **后端调整**：增强了 Webhook 处理及数据库层，确保取消指令的准确执行。
- **UI 更新**：修改 Web 模板以展示 Issue 的取消状态及相关操作。
- **测试增强**：新增 4 个测试文件（+1200+ 行），覆盖取消传播、竞态条件及 Webhook 交互场景。

**影响范围**
后端 Issue 处理核心流程、Webhook 接口、前端 UI 展示及自动化测试。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["backend/models/database.py"]
    N2["backend/services/issue_analyzer.py"]
    N3["backend/services/issue_service.py"]
    N4["backend/services/protocol_repair.py"]
    N5["backend/workers/issue_worker.py"]
    N6["tests/test_issue_cancellation_propagation.py"]
    N7["tests/test_issue_cancellation_races.py"]
    N8["tests/test_issue_worker_cancellation.py"]
    N9["backend/api/webhook.py"]
    N10["tests/test_issue_cancelled_ui.py"]
    N11["tests/test_issue_webhook_cancellation.py"]
    N2 --> N4
    N3 --> N1
    N5 --> N1
    N5 --> N2
    N5 --> N3
    N6 --> N2
    N6 --> N4
    N7 --> N3
    N7 --> N5
    N8 --> N5
```

<!-- sakura-ai-depgraph-end -->

<!-- sakura-ai-issue-links-start -->

Resolves #536

<!-- sakura-ai-issue-links-end -->