### PR TITLE
feat: enhance uninstall --purge to remove all images and refactor menu layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ sudo ./start.sh --prod
 >
 > `reinstall` 会先通过 updater 内部锁原子关闭新任务提交并确认没有活动任务，再依次停止、安装、启动并输出新状态；安装失败时会尝试恢复原有 daemon。旧版 updater 若不支持原子维护门禁，命令会 fail-closed，并要求管理员先显式停止旧 daemon。安装器按部署状态选择具体 Sakura AI Release，但它本身不会强制检查应用健康状态。请把“`/health` 成功返回预期新版本”作为必须人工确认的前置条件；如果健康检查失败、不可用或版本不符，请勿执行。完整验证方法见[部署指南的 Host Updater 章节](docs/DEPLOYMENT.md#webui-更新后同步-host-updater)。
 
-卸载默认保留数据库等 Docker 数据卷；只有显式 `--purge` 才会删除数据卷和 `.deploy` 部署状态：
+卸载分两级：标准卸载保留数据库等 Docker 数据卷，可随时重新部署；显式 `--purge` 完全卸载会删除数据卷、全部镜像（Web/MySQL/Redis/sandboxd/Agent runner）和 `.deploy` 部署状态。两种模式共用同一确认词 `UNINSTALL`：
 
 ```bash
-sudo ./start.sh uninstall          # 保留数据，可重新部署
-sudo ./start.sh uninstall --purge  # 永久删除数据库/缓存卷与部署状态
+sudo ./start.sh uninstall          # 标准卸载：保留数据，可重新部署
+sudo ./start.sh uninstall --purge  # 完全卸载：永久删除数据卷、镜像与部署状态
 ```
 
 **仅 Web 镜像**（MySQL/Redis 自备）：

--- a/README_EN.md
+++ b/README_EN.md
@@ -181,11 +181,11 @@ sudo ./start.sh --prod
 >
 > `reinstall` first uses the updater's internal lock to atomically close new submissions and prove that no job is active, then stops, installs, starts, and reports the new daemon state; if installation fails, it attempts to restore the existing daemon. If an older updater does not support the atomic maintenance gate, the command fails closed and requires the administrator to stop that legacy daemon explicitly first. The installer selects a concrete Sakura AI Release from deployment state, but it does not enforce application health. Treat a successful `/health` response containing the expected new version as a mandatory manual prerequisite; do not continue if the health check fails, is unavailable, or reports a different version. See the [Host Updater section of the Deployment Guide](docs/DEPLOYMENT.md#webui-更新后同步-host-updater) for complete verification steps.
 
-Uninstall preserves Docker data volumes by default. Only explicit `--purge` removes the volumes and `.deploy` state:
+Uninstall has two levels. The standard uninstall preserves Docker data volumes for a later redeployment; explicit `--purge` removes the volumes, all images (Web/MySQL/Redis/sandboxd/Agent runner), and the `.deploy` state. Both modes share the single `UNINSTALL` confirmation word:
 
 ```bash
-sudo ./start.sh uninstall          # Preserve data for a later redeployment
-sudo ./start.sh uninstall --purge  # Permanently delete database/cache volumes and deployment state
+sudo ./start.sh uninstall          # Standard uninstall: preserve data for a later redeployment
+sudo ./start.sh uninstall --purge  # Full uninstall: permanently delete volumes, images, and deployment state
 ```
 
 **Web image only** (bring your own MySQL/Redis):

--- a/start.sh
+++ b/start.sh
@@ -14,7 +14,7 @@
 #   ./start.sh --ps           # 查看服务容器状态
 #   ./start.sh --down         # 停止服务
 #   ./start.sh uninstall      # 卸载服务（默认保留 Docker 数据卷）
-#   ./start.sh uninstall --purge  # 同时删除 Docker 数据卷和 .deploy 状态
+#   ./start.sh uninstall --purge  # 完全卸载：删除数据卷、镜像和 .deploy 状态
 #
 # Agent sandboxd 由本脚本独立管理（不属于 Compose services）：
 #   - sandboxd 容器独占 Docker API socket；Web/runner 永不挂载该 socket。
@@ -4341,19 +4341,21 @@ render_main_menu() {
     ui_line "  ${DIM}后台任务: ${phase}${RESET}"
     ui_line "  ${DIM}Updater : ${daemon}${RESET}"
     ui_blank
+# Menu order follows the service lifecycle: control, status, build/deploy,
+# images, administration.
     ui_line "  ${BOLD}[1]${RESET} 启动服务 (自动检测构建)"
-    ui_line "  ${BOLD}[2]${RESET} 强制重建镜像并启动"
-    ui_line "  ${BOLD}[3]${RESET} 更新镜像 (当前频道)"
-    ui_line "  ${BOLD}[4]${RESET} 切换镜像频道 (正式/开发)"
-    ui_line "  ${BOLD}[5]${RESET} 查看构建/运行状态"
-    ui_line "  ${BOLD}[6]${RESET} 附加到构建日志"
-    ui_line "  ${BOLD}[7]${RESET} 停止正在进行的构建"
-    ui_line "  ${BOLD}[8]${RESET} 查看服务容器状态"
-    ui_line "  ${BOLD}[9]${RESET} 停止服务"
-    ui_line "  ${BOLD}[10]${RESET} 生产镜像部署"
-    ui_line "  ${BOLD}[11]${RESET} Updater daemon 管理"
-    ui_line "  ${BOLD}[12]${RESET} 卸载 Sakura AI"
-    ui_line "  ${BOLD}[13]${RESET} Agent sandboxd 状态"
+    ui_line "  ${BOLD}[2]${RESET} 停止服务"
+    ui_line "  ${BOLD}[3]${RESET} 查看构建/运行状态"
+    ui_line "  ${BOLD}[4]${RESET} 查看服务容器状态"
+    ui_line "  ${BOLD}[5]${RESET} Agent sandboxd 状态"
+    ui_line "  ${BOLD}[6]${RESET} 强制重建镜像并启动"
+    ui_line "  ${BOLD}[7]${RESET} 生产镜像部署"
+    ui_line "  ${BOLD}[8]${RESET} 附加到构建日志"
+    ui_line "  ${BOLD}[9]${RESET} 停止正在进行的构建"
+    ui_line "  ${BOLD}[10]${RESET} 更新镜像 (当前频道)"
+    ui_line "  ${BOLD}[11]${RESET} 切换镜像频道 (正式/开发)"
+    ui_line "  ${BOLD}[12]${RESET} Updater daemon 管理"
+    ui_line "  ${BOLD}[13]${RESET} 卸载 Sakura AI"
     ui_line "  ${BOLD}[0]${RESET} 退出"
     ui_blank
 }
@@ -4373,18 +4375,18 @@ menu_loop() {
         read -rp "  请选择操作: " choice || exit 0
         case "$choice" in
             1)  menu_run do_start false ;;
-            2)  menu_run do_start true ;;
-            3)  menu_run cmd_update_image ;;
-            4)  menu_run cmd_switch_channel ;;
-            5)  menu_run cmd_status ;;
-            6)  menu_run cmd_attach ;;
-            7)  menu_run cmd_stop ;;
-            8)  menu_run do_ps ;;
-            9)  menu_run do_down ;;
-            10) menu_run do_start false true ;;
-            11) updater_menu_loop ;;
-            12) menu_run cmd_uninstall ;;
-            13) menu_run cmd_sandbox status ;;
+            2)  menu_run do_down ;;
+            3)  menu_run cmd_status ;;
+            4)  menu_run do_ps ;;
+            5)  menu_run cmd_sandbox status ;;
+            6)  menu_run do_start true ;;
+            7)  menu_run do_start false true ;;
+            8)  menu_run cmd_attach ;;
+            9)  menu_run cmd_stop ;;
+            10) menu_run cmd_update_image ;;
+            11) menu_run cmd_switch_channel ;;
+            12) updater_menu_loop ;;
+            13) uninstall_menu_loop ;;
             0)  info "已退出" ; exit 0 ;;
             *)  warn "无效选项: $choice" ; sleep 1 ;;
         esac
@@ -4425,6 +4427,33 @@ updater_menu_loop() {
     done
 }
 
+# 卸载子菜单：标准卸载保留数据卷与部署状态，完全卸载追加数据卷/镜像/部署状态清除。
+# Uninstall submenu: standard uninstall keeps volumes and deployment state;
+# full uninstall additionally removes volumes, images, and deployment state.
+render_uninstall_menu() {
+    ui_title "卸载 Sakura AI"
+    ui_blank
+    ui_line "  ${BOLD}[1]${RESET} 标准卸载 (保留数据卷和部署状态，可重新部署)"
+    ui_line "  ${BOLD}[2]${RESET} 完全卸载 (删除数据卷、镜像和部署状态)"
+    ui_line "  ${BOLD}[0]${RESET} 返回主菜单"
+    ui_blank
+}
+
+uninstall_menu_loop() {
+    local choice
+    while true; do
+        render_uninstall_menu
+        ui_render
+        read -rp "  请选择操作: " choice || exit 0
+        case "$choice" in
+            1) menu_run cmd_uninstall ;;
+            2) menu_run cmd_uninstall --purge ;;
+            0) return 0 ;;
+            *) warn "无效选项: $choice" ; sleep 1 ;;
+        esac
+    done
+}
+
 do_ps() {
     local prod=${1:-false}
     select_compose_for_operation "$prod"
@@ -4440,7 +4469,7 @@ do_ps() {
 }
 
 confirm_sakura_uninstall() {
-    local purge="$1" assume_yes="$2" expected answer
+    local purge="$1" assume_yes="$2" answer
     if [[ "$assume_yes" == "true" ]]; then
         return 0
     fi
@@ -4449,16 +4478,16 @@ confirm_sakura_uninstall() {
         return 1
     fi
     echo ""
-    warn "即将停止并删除 Sakura AI 容器、网络和 Host Updater。"
     if [[ "$purge" == "true" ]]; then
-        warn "--purge 还会永久删除 Compose 数据卷（包括 MySQL/Redis）和 .deploy 状态。"
-        expected="PURGE SAKURA-AI"
+        warn "完全卸载将删除容器、网络、数据卷、全部镜像和 .deploy 部署状态，不可恢复。"
     else
+        warn "即将停止并删除 Sakura AI 容器、网络和 Host Updater。"
         info "Docker 数据卷和 .deploy/deployment.env 将保留，可供以后重新部署。"
-        expected="UNINSTALL"
     fi
-    read -r -p "输入 '$expected' 继续: " answer
-    if [[ "$answer" != "$expected" ]]; then
+    # 标准与完全卸载共用同一确认词，避免引入额外的确认提示词。
+    # Both modes share the single UNINSTALL confirmation word.
+    read -r -p "输入 'UNINSTALL' 继续: " answer
+    if [[ "$answer" != "UNINSTALL" ]]; then
         fail "确认内容不匹配，已取消卸载" >&2
         return 1
     fi
@@ -4510,9 +4539,28 @@ sakura_compose_uninstall() {
     fi
     compose_cmd+=(-f "$COMPOSE_FILE" down --remove-orphans)
     if [[ "$purge" == "true" ]]; then
-        compose_cmd+=(--volumes)
+        # 完全卸载连带删除整个 Compose 栈镜像 (Web/MySQL/Redis)。
+        # Full uninstall also removes every image used by the Compose stack.
+        compose_cmd+=(--volumes --rmi all)
     fi
     "${compose_cmd[@]}"
+}
+
+# 完全卸载时按 deployment.env 记录删除 sandboxd/Agent runner 镜像。
+# Remove sandboxd/Agent runner images recorded in deployment.env during a
+# full uninstall.  Must run before purge_sakura_deployment_state: once the
+# state is gone the image references cannot be recovered.  A missing or
+# in-use image only warns and never blocks the rest of the uninstall.
+purge_sakura_images() {
+    local image
+    sandbox_load_deployment_config || return $?
+    for image in "$SANDBOX_IMAGE" "$SANDBOX_RUNNER_IMAGE"; do
+        [[ -n "$image" ]] || continue
+        docker image inspect "$image" >/dev/null 2>&1 || continue
+        info "正在删除镜像 $image..."
+        docker rmi "$image" >/dev/null 2>&1 \
+            || warn "镜像 $image 删除失败（可能被占用），已跳过"
+    done
 }
 
 purge_sakura_deployment_state() {
@@ -4555,8 +4603,10 @@ cmd_uninstall() {
     sakura_compose_uninstall "$purge" || return $?
     cmd_updater_uninstall || return $?
     if [[ "$purge" == "true" ]]; then
+        # 先按 deployment.env 记录删除 sandboxd/runner 镜像，再清除部署状态。
+        purge_sakura_images || return $?
         purge_sakura_deployment_state || return $?
-        ok "Sakura AI 已完全卸载；Compose 数据卷和部署状态已删除"
+        ok "Sakura AI 已完全卸载；数据卷、镜像和部署状态已删除"
     else
         ok "Sakura AI 已卸载；Docker 数据卷和部署状态已保留"
     fi
@@ -4790,7 +4840,7 @@ main() {
                 echo "  --ps        查看服务容器状态"
                 echo "  --down      停止服务"
                 echo "  --help      显示帮助"
-                echo "  uninstall [--purge] [--yes]  卸载服务；默认保留数据，--purge 删除数据卷"
+                echo "  uninstall [--purge] [--yes]  卸载服务；默认保留数据，--purge 完全卸载（含数据卷/镜像/部署状态）"
                 echo "  生产 Agent 沙箱由独立 sandboxd 管理；生产必须配置 runner immutable digest"
                 echo "  updater [action]  管理 host updater daemon（含 reinstall/uninstall；生产操作需 root）"
                 echo "  sandboxd [action] 管理 Agent sandboxd（start/stop/restart/reinstall/uninstall/status）"

--- a/start.sh
+++ b/start.sh
@@ -4546,21 +4546,32 @@ sakura_compose_uninstall() {
     "${compose_cmd[@]}"
 }
 
-# 完全卸载时按 deployment.env 记录删除 sandboxd/Agent runner 镜像。
-# Remove sandboxd/Agent runner images recorded in deployment.env during a
-# full uninstall.  Must run before purge_sakura_deployment_state: once the
-# state is gone the image references cannot be recovered.  A missing or
-# in-use image only warns and never blocks the rest of the uninstall.
+# 完全卸载时删除 Sakura 官方仓库的全部本地镜像 (web/sandboxd/Agent runner)。
+# Remove every local image from the official Sakura repositories during a
+# full uninstall.  ``compose down --rmi all`` and the persisted references
+# only cover the current release: digest pulls leave untagged images whose
+# identity lives only in RepoDigests, and updater-driven releases keep old
+# version tags behind.  Enumerating by repository prefix covers all three;
+# a missing or in-use image only warns and never blocks the uninstall.
 purge_sakura_images() {
-    local image
-    sandbox_load_deployment_config || return $?
-    for image in "$SANDBOX_IMAGE" "$SANDBOX_RUNNER_IMAGE"; do
-        [[ -n "$image" ]] || continue
-        docker image inspect "$image" >/dev/null 2>&1 || continue
-        info "正在删除镜像 $image..."
-        docker rmi "$image" >/dev/null 2>&1 \
-            || warn "镜像 $image 删除失败（可能被占用），已跳过"
-    done
+    local id repo tag digests
+    while read -r id repo tag; do
+        [[ -n "$id" ]] || continue
+        if [[ "$repo" == "<none>" ]]; then
+            # 无 tag 镜像按 RepoDigests 判定归属，避免误删无关 dangling 层。
+            digests=$(docker image inspect --format '{{join .RepoDigests " "}}' "$id" 2>/dev/null) \
+                || continue
+            [[ "$digests" == *"ghcr.io/sakura520222/sakura-ai"* ]] || continue
+        else
+            case "$repo" in
+                ghcr.io/sakura520222/sakura-ai | ghcr.io/sakura520222/sakura-ai-*) ;;
+                *) continue ;;
+            esac
+        fi
+        info "正在删除镜像 ($id) $repo:$tag..."
+        docker rmi -f "$id" >/dev/null 2>&1 \
+            || warn "镜像 $id 删除失败（可能被占用），已跳过"
+    done < <(docker image ls --format '{{.ID}} {{.Repository}} {{.Tag}}' | awk '!seen[$1]++')
 }
 
 purge_sakura_deployment_state() {
@@ -4603,7 +4614,8 @@ cmd_uninstall() {
     sakura_compose_uninstall "$purge" || return $?
     cmd_updater_uninstall || return $?
     if [[ "$purge" == "true" ]]; then
-        # 先按 deployment.env 记录删除 sandboxd/runner 镜像，再清除部署状态。
+        # 按仓库前缀枚举删除全部本地 Sakura 镜像（含历史版本与 digest-pull
+        # 镜像），再清除部署状态。
         purge_sakura_images || return $?
         purge_sakura_deployment_state || return $?
         ok "Sakura AI 已完全卸载；数据卷、镜像和部署状态已删除"

--- a/tests/test_start_sh_uninstall.py
+++ b/tests/test_start_sh_uninstall.py
@@ -95,21 +95,24 @@ def test_full_uninstall_removes_compose_stack_images():
     assert "compose_cmd+=(--volumes --rmi all)" in script
 
 
-def test_full_uninstall_removes_recorded_images_before_deployment_state():
+def test_full_uninstall_purges_images_by_repository_before_state():
     script = (ROOT / "start.sh").read_text(encoding="utf-8")
     purge_images = script.index("purge_sakura_images() {")
     cmd_uninstall = script.index("cmd_uninstall() {")
     body = script[cmd_uninstall:]
-    # Images must be removed while deployment.env still exists, then the
-    # deployment state is purged.
+    # Image removal must still happen before the deployment state is purged.
     assert "purge_sakura_images || return $?" in body
     assert body.index("purge_sakura_images || return $?") < body.index(
         "purge_sakura_deployment_state || return $?"
     )
-    # Recorded sandboxd/runner references drive the removal loop.
+    # The loop enumerates local images by repository prefix: digest pulls
+    # leave untagged images only attributable via RepoDigests, and updater
+    # releases keep old version tags behind that --rmi all never sees.
     loop_body = script[purge_images: script.index("purge_sakura_deployment_state() {")]
-    assert 'for image in "$SANDBOX_IMAGE" "$SANDBOX_RUNNER_IMAGE"' in loop_body
-    assert 'docker rmi "$image"' in loop_body
+    assert "docker image ls --format '{{.ID}} {{.Repository}} {{.Tag}}'" in loop_body
+    assert "ghcr.io/sakura520222/sakura-ai-*) ;;" in loop_body
+    assert "{{join .RepoDigests \" \"}}" in loop_body
+    assert 'docker rmi -f "$id"' in loop_body
 
 
 def test_uninstall_help_documents_purge_semantics():

--- a/tests/test_start_sh_uninstall.py
+++ b/tests/test_start_sh_uninstall.py
@@ -1,0 +1,141 @@
+"""Structural contracts for the start.sh uninstall submenu and main menu order.
+
+Covers the design in
+docs/superpowers/specs/2026-08-28-start-sh-uninstall-subcommands-design.md:
+menu lifecycle ordering, the uninstall submenu, the unified UNINSTALL
+confirmation word, and full-uninstall image removal ordering.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+
+# Menu order follows the service lifecycle: control, status, build/deploy,
+# images, administration.
+MAIN_MENU_ORDER = (
+    "启动服务 (自动检测构建)",
+    "停止服务",
+    "查看构建/运行状态",
+    "查看服务容器状态",
+    "Agent sandboxd 状态",
+    "强制重建镜像并启动",
+    "生产镜像部署",
+    "附加到构建日志",
+    "停止正在进行的构建",
+    "更新镜像 (当前频道)",
+    "切换镜像频道 (正式/开发)",
+    "Updater daemon 管理",
+    "卸载 Sakura AI",
+)
+
+
+def test_main_menu_order_follows_lifecycle_groups():
+    script = (ROOT / "start.sh").read_text(encoding="utf-8")
+    # Menu entries appear in ascending order inside render_main_menu.
+    positions = [
+        script.index(f'ui_line "  ${{BOLD}}[{number}]${{RESET}} {label}"')
+        for number, label in enumerate(MAIN_MENU_ORDER, start=1)
+    ]
+    assert positions == sorted(positions)
+    assert 'ui_line "  ${BOLD}[0]${RESET} 退出"' in script
+
+
+def test_main_menu_actions_map_to_reordered_entries():
+    script = (ROOT / "start.sh").read_text(encoding="utf-8")
+    expected = (
+        "1)  menu_run do_start false ;;",
+        "2)  menu_run do_down ;;",
+        "3)  menu_run cmd_status ;;",
+        "4)  menu_run do_ps ;;",
+        "5)  menu_run cmd_sandbox status ;;",
+        "6)  menu_run do_start true ;;",
+        "7)  menu_run do_start false true ;;",
+        "8)  menu_run cmd_attach ;;",
+        "9)  menu_run cmd_stop ;;",
+        "10) menu_run cmd_update_image ;;",
+        "11) menu_run cmd_switch_channel ;;",
+        "12) updater_menu_loop ;;",
+        "13) uninstall_menu_loop ;;",
+    )
+    for entry in expected:
+        assert entry in script
+
+
+def test_uninstall_submenu_offers_standard_and_full_levels():
+    script = (ROOT / "start.sh").read_text(encoding="utf-8")
+    assert "render_uninstall_menu" in script
+    assert "uninstall_menu_loop" in script
+    assert "标准卸载 (保留数据卷和部署状态，可重新部署)" in script
+    assert "完全卸载 (删除数据卷、镜像和部署状态)" in script
+    assert "1) menu_run cmd_uninstall ;;" in script
+    assert "2) menu_run cmd_uninstall --purge ;;" in script
+    assert "0) return 0 ;;" in script
+
+
+def test_uninstall_confirmation_uses_single_uninstall_word():
+    script = (ROOT / "start.sh").read_text(encoding="utf-8")
+    # Both modes share the single confirmation word; the legacy per-mode
+    # "PURGE SAKURA-AI" prompt must stay removed.
+    assert "输入 'UNINSTALL' 继续: " in script
+    assert "PURGE SAKURA-AI" not in script
+    assert 'expected="PURGE' not in script
+    assert 'expected="UNINSTALL"' not in script
+
+
+def test_full_uninstall_removes_compose_stack_images():
+    script = (ROOT / "start.sh").read_text(encoding="utf-8")
+    # --rmi all only joins the purge branch so a standard uninstall keeps
+    # the stack images for a later redeployment.
+    assert "compose_cmd+=(--volumes --rmi all)" in script
+
+
+def test_full_uninstall_removes_recorded_images_before_deployment_state():
+    script = (ROOT / "start.sh").read_text(encoding="utf-8")
+    purge_images = script.index("purge_sakura_images() {")
+    cmd_uninstall = script.index("cmd_uninstall() {")
+    body = script[cmd_uninstall:]
+    # Images must be removed while deployment.env still exists, then the
+    # deployment state is purged.
+    assert "purge_sakura_images || return $?" in body
+    assert body.index("purge_sakura_images || return $?") < body.index(
+        "purge_sakura_deployment_state || return $?"
+    )
+    # Recorded sandboxd/runner references drive the removal loop.
+    loop_body = script[purge_images: script.index("purge_sakura_deployment_state() {")]
+    assert 'for image in "$SANDBOX_IMAGE" "$SANDBOX_RUNNER_IMAGE"' in loop_body
+    assert 'docker rmi "$image"' in loop_body
+
+
+def test_uninstall_help_documents_purge_semantics():
+    script = (ROOT / "start.sh").read_text(encoding="utf-8")
+    assert "卸载服务；默认保留数据，--purge 完全卸载（含数据卷/镜像/部署状态）" in script
+    assert "完全卸载：删除数据卷、镜像和 .deploy 状态" in script
+
+
+def test_readme_documents_two_uninstall_levels():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    readme_en = (ROOT / "README_EN.md").read_text(encoding="utf-8")
+    assert "标准卸载：保留数据，可重新部署" in readme
+    assert "完全卸载：永久删除数据卷、镜像与部署状态" in readme
+    assert "Standard uninstall: preserve data for a later redeployment" in readme_en
+    assert "permanently delete volumes, images, and deployment state" in readme_en
+
+
+def test_start_script_is_bash_valid_when_bash_is_available():
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is unavailable on this host")
+    result = subprocess.run(
+        [bash, "-n", "start.sh"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_start_sh_uninstall.sh
+++ b/tests/test_start_sh_uninstall.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# start.sh 卸载行为的函数级测试：确认门禁、compose purge 参数、镜像清理循环。
+# Function-level tests for start.sh uninstall behaviour: confirmation gate,
+# compose purge flags, and the recorded-image removal loop.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export _START_SH_SOURCED=1
+source "$SCRIPT_DIR/start.sh"
+set +e
+
+pass=0; fail=0
+report() { if [ "$1" -eq 0 ]; then echo "[OK] $2"; pass=$((pass+1)); else echo "[FAIL] $2"; fail=$((fail+1)); fi; }
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# fake docker 记录 argv 供断言；image inspect 仅对预设存在的镜像返回 0。
+FAKE_LOG="$TMPDIR/docker_calls.log"
+EXISTING_IMAGE="ghcr.io/sakura520222/sakura-ai-sandboxd:persisted"
+docker() {
+    printf '%s\n' "$*" >> "$FAKE_LOG"
+    case "$1" in
+        image)
+            # 仅 sandboxd 镜像视为存在；runner 镜像不存在以覆盖跳过分支。
+            [ "$2" = "inspect" ] && [ "$3" = "$EXISTING_IMAGE" ] && return 0
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# --- C 组：确认门禁 ---
+
+# C1: --yes 直接通过，无需交互终端
+confirm_sakura_uninstall false true
+report $? "C1: --yes 跳过确认"
+
+# C2: 非交互且无 --yes 时拒绝（stdin 非 tty）
+confirm_sakura_uninstall false false </dev/null >/dev/null 2>&1
+[ $? -ne 0 ] && report 0 "C2: 非交互无 --yes 拒绝" || report 1 "C2: 非交互无 --yes 拒绝"
+
+# C3: 确认提示只包含统一确认词 UNINSTALL；旧词已移除
+if declare -F confirm_sakura_uninstall >/dev/null; then
+    if ! grep -q "PURGE SAKURA-AI" "$SCRIPT_DIR/start.sh"; then
+        report 0 "C3: 统一 UNINSTALL 确认词（无 PURGE SAKURA-AI）"
+    else
+        report 1 "C3: 统一 UNINSTALL 确认词（无 PURGE SAKURA-AI）"
+    fi
+else
+    report 1 "C3: 统一 UNINSTALL 确认词（无 PURGE SAKURA-AI）"
+fi
+
+# --- K 组：compose purge 参数 ---
+
+select_compose_from_deployment_mode() { :; }
+UPDATER_DEPLOYMENT_ENV_FILE=/dev/null
+COMPOSE_PROJECT=""
+COMPOSE_FILE="$TMPDIR/docker-compose.yml"
+
+: > "$FAKE_LOG"
+sakura_compose_uninstall false >/dev/null 2>&1
+grep -q "down --remove-orphans" "$FAKE_LOG" \
+    && ! grep -q -- "--rmi" "$FAKE_LOG" \
+    && report 0 "K1: 标准卸载不加 --rmi" || report 1 "K1: 标准卸载不加 --rmi"
+
+: > "$FAKE_LOG"
+sakura_compose_uninstall true >/dev/null 2>&1
+grep -q -- "down --remove-orphans --volumes --rmi all" "$FAKE_LOG" \
+    && report 0 "K2: 完全卸载追加 --volumes --rmi all" || report 1 "K2: 完全卸载追加 --volumes --rmi all"
+
+# --- P 组：镜像清理循环 ---
+
+cat > "$TMPDIR/deployment.env" <<EOF
+SAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:latest
+SAKURA_SANDBOXD_IMAGE=$EXISTING_IMAGE
+SAKURA_AGENT_RUNNER_IMAGE=ghcr.io/sakura520222/sakura-ai-agent-runner:persisted
+EOF
+DEPLOYMENT_ENV_FILE="$TMPDIR/deployment.env"
+SANDBOX_IMAGE=""
+SANDBOX_RUNNER_IMAGE=""
+
+# P1: 按 deployment.env 记录逐个删除；inspect 失败的镜像跳过
+: > "$FAKE_LOG"
+purge_sakura_images >/dev/null 2>&1
+grep -q -- "rmi $EXISTING_IMAGE" "$FAKE_LOG" \
+    && ! grep -q -- "rmi .*runner:persisted" "$FAKE_LOG" \
+    && report 0 "P1: 记录镜像删除，缺失镜像跳过" || report 1 "P1: 记录镜像删除，缺失镜像跳过"
+
+# P2: rmi 失败不阻断（inspect 命中但删除失败仍返回 0）
+docker() {
+    case "$1" in
+        image)
+            [ "$2" = "inspect" ] && return 0
+            ;;
+    esac
+    return 1
+}
+purge_sakura_images >/dev/null 2>&1
+report $? "P2: rmi 失败仅告警不阻断"
+
+# P3: deployment.env 缺失时安全跳过（inspect 默认引用不存在 → 无 rmi）
+: > "$FAKE_LOG"
+SANDBOX_IMAGE=""
+SANDBOX_RUNNER_IMAGE=""
+rm -f "$TMPDIR/deployment.env"
+purge_sakura_images >/dev/null 2>&1
+if ! grep -q "rmi" "$FAKE_LOG"; then
+    report 0 "P3: 无部署状态时跳过镜像删除"
+else
+    report 1 "P3: 无部署状态时跳过镜像删除"
+fi
+
+echo ""
+echo "结果: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/test_start_sh_uninstall.sh
+++ b/tests/test_start_sh_uninstall.sh
@@ -14,18 +14,10 @@ report() { if [ "$1" -eq 0 ]; then echo "[OK] $2"; pass=$((pass+1)); else echo "
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# fake docker 记录 argv 供断言；image inspect 仅对预设存在的镜像返回 0。
+# fake docker 记录 argv 供断言；compose 与 rmi 默认成功。
 FAKE_LOG="$TMPDIR/docker_calls.log"
-EXISTING_IMAGE="ghcr.io/sakura520222/sakura-ai-sandboxd:persisted"
 docker() {
     printf '%s\n' "$*" >> "$FAKE_LOG"
-    case "$1" in
-        image)
-            # 仅 sandboxd 镜像视为存在；runner 镜像不存在以覆盖跳过分支。
-            [ "$2" = "inspect" ] && [ "$3" = "$EXISTING_IMAGE" ] && return 0
-            return 1
-            ;;
-    esac
     return 0
 }
 
@@ -68,46 +60,66 @@ sakura_compose_uninstall true >/dev/null 2>&1
 grep -q -- "down --remove-orphans --volumes --rmi all" "$FAKE_LOG" \
     && report 0 "K2: 完全卸载追加 --volumes --rmi all" || report 1 "K2: 完全卸载追加 --volumes --rmi all"
 
-# --- P 组：镜像清理循环 ---
+# --- P 组：镜像清理循环（按仓库前缀枚举） ---
 
-cat > "$TMPDIR/deployment.env" <<EOF
-SAKURA_AI_IMAGE=ghcr.io/sakura520222/sakura-ai:latest
-SAKURA_SANDBOXD_IMAGE=$EXISTING_IMAGE
-SAKURA_AGENT_RUNNER_IMAGE=ghcr.io/sakura520222/sakura-ai-agent-runner:persisted
+# image_ls.txt 模拟 docker image ls 输出：历史版本 tag、latest、无 tag 的
+# sandboxd、sakura digest-pull dangling、无关 dangling、无关仓库。
+cat > "$TMPDIR/image_ls.txt" <<'EOF'
+abc111 ghcr.io/sakura520222/sakura-ai v1.2.3
+abc222 ghcr.io/sakura520222/sakura-ai latest
+abc333 ghcr.io/sakura520222/sakura-ai-sandboxd <none>
+abc444 <none> <none>
+abc555 <none> <none>
+abc666 mysql 8.4
 EOF
-DEPLOYMENT_ENV_FILE="$TMPDIR/deployment.env"
-SANDBOX_IMAGE=""
-SANDBOX_RUNNER_IMAGE=""
 
-# P1: 按 deployment.env 记录逐个删除；inspect 失败的镜像跳过
-: > "$FAKE_LOG"
-purge_sakura_images >/dev/null 2>&1
-grep -q -- "rmi $EXISTING_IMAGE" "$FAKE_LOG" \
-    && ! grep -q -- "rmi .*runner:persisted" "$FAKE_LOG" \
-    && report 0 "P1: 记录镜像删除，缺失镜像跳过" || report 1 "P1: 记录镜像删除，缺失镜像跳过"
-
-# P2: rmi 失败不阻断（inspect 命中但删除失败仍返回 0）
 docker() {
-    case "$1" in
-        image)
-            [ "$2" = "inspect" ] && return 0
+    printf '%s\n' "$*" >> "$FAKE_LOG"
+    case "$1 $2" in
+        "image ls") cat "$TMPDIR/image_ls.txt" ;;
+        "image inspect")
+            # argv: image inspect --format <template> <id> → id 为 $5。
+            case "$5" in
+                abc444) printf '%s\n' '[ghcr.io/sakura520222/sakura-ai-agent-runner@sha256:0123]' ;;
+                abc555) printf '%s\n' '[postgres@sha256:0123]' ;;
+            esac
             ;;
     esac
-    return 1
+    return 0
+}
+
+# P1: sakura 仓库镜像全删（含历史 tag 与 RepoDigests 归属的 dangling）；无关镜像保留
+: > "$FAKE_LOG"
+purge_sakura_images >/dev/null 2>&1
+grep -q "rmi -f abc111" "$FAKE_LOG" \
+    && grep -q "rmi -f abc222" "$FAKE_LOG" \
+    && grep -q "rmi -f abc333" "$FAKE_LOG" \
+    && grep -q "rmi -f abc444" "$FAKE_LOG" \
+    && ! grep -q "rmi -f abc555" "$FAKE_LOG" \
+    && ! grep -q "rmi -f abc666" "$FAKE_LOG" \
+    && report 0 "P1: 仓库前缀枚举删除，无关镜像保留" || report 1 "P1: 仓库前缀枚举删除，无关镜像保留"
+
+# P2: rmi 失败不阻断（全部删除失败仍返回 0）
+docker() {
+    case "$1" in rmi) return 1 ;; esac
+    return 0
 }
 purge_sakura_images >/dev/null 2>&1
 report $? "P2: rmi 失败仅告警不阻断"
 
-# P3: deployment.env 缺失时安全跳过（inspect 默认引用不存在 → 无 rmi）
+# P3: 无本地镜像时安全跳过
+cat > "$TMPDIR/image_ls.txt" <<'EOF'
+EOF
+docker() {
+    case "$1 $2" in "image ls") cat "$TMPDIR/image_ls.txt" ;; esac
+    return 0
+}
 : > "$FAKE_LOG"
-SANDBOX_IMAGE=""
-SANDBOX_RUNNER_IMAGE=""
-rm -f "$TMPDIR/deployment.env"
 purge_sakura_images >/dev/null 2>&1
-if ! grep -q "rmi" "$FAKE_LOG"; then
-    report 0 "P3: 无部署状态时跳过镜像删除"
+if [ $? -eq 0 ] && [ ! -s "$FAKE_LOG" ]; then
+    report 0 "P3: 无本地镜像时安全跳过"
 else
-    report 1 "P3: 无部署状态时跳过镜像删除"
+    report 1 "P3: 无本地镜像时安全跳过"
 fi
 
 echo ""


### PR DESCRIPTION
- Extend uninstall --purge to completely remove all Docker images (Web, MySQL, Redis, sandboxd, Agent runner) in addition to data volumes and deployment state.
- Update bilingual documentation (README.md, README_EN.md) to clearly distinguish between standard and full uninstallation levels.
- Reorder main menu options in start.sh to logically follow the service lifecycle (control, status, build/deploy, images, administration).
- Adjust menu_loop handler mappings to match the new menu sequence.