### PR TITLE
feat: add detailed build information to about page and API

### DIFF
--- a/backend/api/v1/settings.py
+++ b/backend/api/v1/settings.py
@@ -85,13 +85,19 @@ async def get_about(
     user: dict = Depends(require_api_auth),
 ):
     """获取系统版本信息"""
+    from backend.core.branding import SAKURA_AI_REPO_URL
+    from backend.core.build_info import get_build_info
     from backend.webui.routes.auth import APP_VERSION
 
+    build_info = get_build_info()
     return success_response(
         data={
             "version": APP_VERSION,
             "build_date": get_time_service()
             .to_app_timezone(get_time_service().now_utc())
             .strftime("%Y-%m-%d"),
+            "channel": build_info["channel"],
+            "revision": build_info["revision"],
+            "repo_url": SAKURA_AI_REPO_URL,
         }
     )

--- a/backend/webui/routes/settings.py
+++ b/backend/webui/routes/settings.py
@@ -512,7 +512,24 @@ async def about_page(
     user_prefs: dict = Depends(get_user_preferences),
 ):
     """关于页面"""
+    from backend.core.branding import SAKURA_AI_REPO_URL
+    from backend.core.build_info import get_build_info
     from backend.webui.routes.auth import APP_VERSION
+
+    build_info = get_build_info()
+    # 镜像部署展示真实构建日期；源码部署退化为当天日期（保持旧行为）
+    if build_info["created_at"]:
+        from backend.core.time_service import parse_rfc3339
+
+        build_date = get_time_service().to_app_timezone(
+            parse_rfc3339(build_info["created_at"])
+        ).strftime("%Y-%m-%d")
+    else:
+        build_date = (
+            get_time_service()
+            .to_app_timezone(get_time_service().now_utc())
+            .strftime("%Y-%m-%d")
+        )
 
     return render_template(
         "about.html",
@@ -522,7 +539,8 @@ async def about_page(
         csrf_token=get_csrf_serializer().dumps({}),
         active_page="about",
         app_version=APP_VERSION,
-        build_date=get_time_service()
-        .to_app_timezone(get_time_service().now_utc())
-        .strftime("%Y-%m-%d"),
+        build_date=build_date,
+        build_channel=build_info["channel"],
+        build_revision=build_info["revision"],
+        repo_url=SAKURA_AI_REPO_URL,
     )

--- a/backend/webui/templates/about.html
+++ b/backend/webui/templates/about.html
@@ -3,7 +3,7 @@
 {% block title %}{{ _('about.title') }} - Sakura AI{% endblock %}
 
 {% block content %}
-<div class="space-y-6 max-w-2xl">
+<div class="space-y-6 max-w-4xl mx-auto">
     <!-- 页面标题 -->
     <div>
         <h1 class="text-2xl font-bold bg-gradient-to-r from-sakura-700 to-purple-700 dark:from-sakura-400 dark:to-purple-400 bg-clip-text text-transparent">{{ _('about.title') }}</h1>
@@ -20,8 +20,21 @@
             </div>
             <div>
                 <h2 class="text-xl font-bold">Sakura AI</h2>
-                <div class="flex items-center gap-3 mt-1 text-sm text-gray-500 dark:text-gray-400">
+                <div class="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-sm text-gray-500 dark:text-gray-400">
                     <span class="font-mono">v{{ app_version }}</span>
+                    {% if build_channel == 'stable' %}
+                    <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400">{{ _('about.channel_stable') }}</span>
+                    {% elif build_channel == 'development' %}
+                    <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">{{ _('about.channel_development') }}</span>
+                    {% else %}
+                    <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300">{{ _('about.channel_source') }}</span>
+                    {% endif %}
+                    {% if build_revision %}
+                    <span>|</span>
+                    <a href="{{ repo_url }}/commit/{{ build_revision }}" target="_blank" rel="noopener"
+                       class="font-mono text-sakura-600 dark:text-sakura-400 hover:underline"
+                       title="{{ _('about.build_revision') }}: {{ build_revision }}">{{ build_revision[:7] }}</a>
+                    {% endif %}
                     <span>|</span>
                     <span>{{ build_date }}</span>
                 </div>
@@ -102,6 +115,49 @@
                     <p class="text-xs text-gray-500 dark:text-gray-400">{{ _('about.ai_model') }}</p>
                 </div>
             </div>
+        </div>
+    </div>
+
+    <!-- 项目链接 -->
+    <div class="glass rounded-2xl border border-sakura-200/50 dark:border-sakura-800/30 shadow-sm p-6">
+        <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-4">{{ _('about.links') }}</h3>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <a href="{{ repo_url }}" target="_blank" rel="noopener"
+               class="group flex items-start gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 transition-colors">
+                <div class="w-8 h-8 bg-gray-200 dark:bg-gray-600 rounded-lg flex items-center justify-center shrink-0">
+                    <svg class="w-4 h-4 text-gray-700 dark:text-gray-300" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
+                    </svg>
+                </div>
+                <div>
+                    <p class="text-sm font-medium group-hover:text-sakura-600 dark:group-hover:text-sakura-400 transition-colors">{{ _('about.github_repo') }}</p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">{{ _('about.github_repo_desc') }}</p>
+                </div>
+            </a>
+            <a href="{{ repo_url }}#readme" target="_blank" rel="noopener"
+               class="group flex items-start gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 transition-colors">
+                <div class="w-8 h-8 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center shrink-0">
+                    <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+                    </svg>
+                </div>
+                <div>
+                    <p class="text-sm font-medium group-hover:text-sakura-600 dark:group-hover:text-sakura-400 transition-colors">{{ _('about.documentation') }}</p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">{{ _('about.documentation_desc') }}</p>
+                </div>
+            </a>
+            <a href="{{ repo_url }}/issues" target="_blank" rel="noopener"
+               class="group flex items-start gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50 hover:bg-sakura-50 dark:hover:bg-sakura-900/20 transition-colors">
+                <div class="w-8 h-8 bg-rose-100 dark:bg-rose-900/30 rounded-lg flex items-center justify-center shrink-0">
+                    <svg class="w-4 h-4 text-rose-600 dark:text-rose-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 100-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 100-4m0 4v2m0-6V4"/>
+                    </svg>
+                </div>
+                <div>
+                    <p class="text-sm font-medium group-hover:text-sakura-600 dark:group-hover:text-sakura-400 transition-colors">{{ _('about.report_issue') }}</p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">{{ _('about.report_issue_desc') }}</p>
+                </div>
+            </a>
         </div>
     </div>
 </div>

--- a/backend/webui/templates/base.html
+++ b/backend/webui/templates/base.html
@@ -738,7 +738,7 @@
         <div class="ml-0 lg:ml-64 flex flex-col sm:flex-row items-center justify-between gap-2 text-xs text-gray-400 dark:text-gray-500">
             <div class="flex items-center gap-2">
                 <span>🌸</span>
-                <span>&copy; 2025-2026 Sakura AI</span>
+                <span>&copy; 2026 Sakura AI</span>
             </div>
             <div class="flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
                 <a href="/pricing" class="hover:text-sakura-600 dark:hover:text-sakura-400 transition-colors">Pricing</a>

--- a/backend/webui/templates/legal/base.html
+++ b/backend/webui/templates/legal/base.html
@@ -60,7 +60,7 @@
         <div class="max-w-4xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-gray-500 dark:text-gray-400">
             <div class="flex items-center gap-2">
                 <span>🌸</span>
-                <span>&copy; 2025-2026 Sakura AI. All rights reserved.</span>
+                <span>&copy; 2026 Sakura AI. All rights reserved.</span>
             </div>
             <div class="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
                 <a href="/terms" class="hover:text-sakura-600 dark:hover:text-sakura-400 transition-colors">Terms of Service</a>

--- a/backend/webui/translations/en.yaml
+++ b/backend/webui/translations/en.yaml
@@ -1536,6 +1536,10 @@ version_manager:
 about:
   title: "About"
   version: "Version"
+  channel_stable: "Stable"
+  channel_development: "Development"
+  channel_source: "Source"
+  build_revision: "Build Revision"
   tech_stack: "Tech Stack"
   backend_runtime: "Backend Runtime"
   web_framework: "Web Framework"
@@ -1543,6 +1547,13 @@ about:
   ai_model: "AI Model"
   cache: "Cache"
   description: "Sakura AI is an intelligent GitHub PR/Issue review bot that leverages AI to automatically analyze code quality, detect issues, and provide improvement suggestions."
+  links: "Project Links"
+  github_repo: "GitHub Repository"
+  github_repo_desc: "Browse the source and star the project"
+  documentation: "Documentation"
+  documentation_desc: "Deployment, configuration and usage guides"
+  report_issue: "Report an Issue"
+  report_issue_desc: "Submit an issue or feature request"
 
 # ========== Error ==========
 error:

--- a/backend/webui/translations/zh-CN.yaml
+++ b/backend/webui/translations/zh-CN.yaml
@@ -1537,6 +1537,10 @@ version_manager:
 about:
   title: "关于"
   version: "版本"
+  channel_stable: "稳定版"
+  channel_development: "开发版"
+  channel_source: "源码"
+  build_revision: "构建修订"
   tech_stack: "技术栈"
   backend_runtime: "后端运行时"
   web_framework: "Web 框架"
@@ -1544,6 +1548,13 @@ about:
   ai_model: "AI 模型"
   cache: "缓存"
   description: "Sakura AI 是一个智能的 GitHub PR/Issue 审查机器人，利用 AI 技术自动分析代码质量、发现问题并提供改进建议。"
+  links: "项目链接"
+  github_repo: "GitHub 仓库"
+  github_repo_desc: "浏览源码、提交 Star"
+  documentation: "使用文档"
+  documentation_desc: "部署、配置与使用指南"
+  report_issue: "问题反馈"
+  report_issue_desc: "提交 Issue 或功能建议"
 
 # ========== 错误页面 / Error ==========
 error:

--- a/tests/test_about_page.py
+++ b/tests/test_about_page.py
@@ -1,0 +1,106 @@
+"""关于页面与 /settings/about API 版本信息测试（Issue #534）。
+
+覆盖：GitHub 仓库/文档/Issue 反馈外链渲染、更新频道徽章、
+构建修订短哈希链接，以及 API 返回的构建身份字段。
+"""
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from backend.api.v1.deps import require_api_auth
+from backend.api.v1.settings import router as api_settings_router
+from backend.core.branding import SAKURA_AI_REPO_URL
+from backend.webui.deps import get_user_preferences, require_auth
+from backend.webui.routes.settings import router as settings_router
+
+_REVISION = "a1b2c3d" + "0" * 33
+
+
+def _build_webui_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(settings_router)
+    app.dependency_overrides[require_auth] = lambda: {
+        "user_id": 1,
+        "sub": "tester",
+        "role": "super_admin",
+    }
+    app.dependency_overrides[get_user_preferences] = lambda: {
+        "language": "zh-CN",
+        "items_per_page": 20,
+    }
+    return app
+
+
+def _build_api_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(api_settings_router)
+    app.dependency_overrides[require_api_auth] = lambda: {
+        "user_id": 1,
+        "sub": "tester",
+        "role": "super_admin",
+    }
+    return app
+
+
+def test_about_page_renders_project_links():
+    """关于页渲染 GitHub 仓库、文档与 Issue 反馈外链。"""
+    client = TestClient(_build_webui_app())
+    resp = client.get("/settings/about")
+    assert resp.status_code == 200
+    assert SAKURA_AI_REPO_URL in resp.text
+    assert f"{SAKURA_AI_REPO_URL}/issues" in resp.text
+    assert f"{SAKURA_AI_REPO_URL}#readme" in resp.text
+
+
+def test_about_page_source_channel_badge():
+    """无构建环境变量时（源码部署）渲染源码频道徽章。"""
+    client = TestClient(_build_webui_app())
+    resp = client.get("/settings/about")
+    assert resp.status_code == 200
+    assert "源码" in resp.text
+
+
+def test_about_page_stable_channel_with_revision_link():
+    """注入镜像构建环境变量时渲染稳定徽章、构建日期与 commit 短哈希链接。"""
+    import os
+
+    os.environ["SAKURA_BUILD_CHANNEL"] = "stable"
+    os.environ["SAKURA_BUILD_REVISION"] = _REVISION
+    os.environ["SAKURA_BUILD_CREATED"] = "2026-01-15T12:00:00Z"
+    try:
+        client = TestClient(_build_webui_app())
+        resp = client.get("/settings/about")
+    finally:
+        for key in (
+            "SAKURA_BUILD_CHANNEL",
+            "SAKURA_BUILD_REVISION",
+            "SAKURA_BUILD_CREATED",
+        ):
+            os.environ.pop(key, None)
+    assert resp.status_code == 200
+    assert "稳定版" in resp.text
+    assert f"{SAKURA_AI_REPO_URL}/commit/{_REVISION}" in resp.text
+    assert _REVISION[:7] in resp.text
+
+
+def test_api_about_returns_build_identity():
+    """GET /settings/about 返回版本、频道、修订与仓库地址。"""
+    import os
+
+    os.environ["SAKURA_BUILD_CHANNEL"] = "development"
+    os.environ["SAKURA_BUILD_REVISION"] = _REVISION
+    try:
+        client = TestClient(_build_api_app())
+        resp = client.get("/settings/about")
+    finally:
+        os.environ.pop("SAKURA_BUILD_CHANNEL", None)
+        os.environ.pop("SAKURA_BUILD_REVISION", None)
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["success"] is True
+    data = payload["data"]
+    assert data["version"]
+    assert data["channel"] == "development"
+    assert data["revision"] == _REVISION
+    assert data["repo_url"] == SAKURA_AI_REPO_URL
+    assert data["build_date"]


### PR DESCRIPTION
- Expose build channel, revision, and repository URL in the settings API
- Display color-coded build channel badges (stable, development, source)
- Show short commit hash with a clickable link to the repository
- Use actual build date for mirror deployments, fallback to current date for source builds
- Increase about page container width and add project links section