### PR TITLE
feat(ai-reviewer): track actual GitHub refs and clarify line-range behavior in read_file tool

### DIFF
--- a/backend/services/ai_reviewer/constants.py
+++ b/backend/services/ai_reviewer/constants.py
@@ -101,7 +101,12 @@ READ_FILE_TOOL = {
             "1. 完整读取（仅指定file_path）\n"
             "2. 行范围读取（指定start_line和end_line）\n"
             "3. 内容搜索（指定search_pattern，返回匹配行及上下文）\n"
-            "返回内容始终包含行号，方便定位。"
+            "返回内容始终包含行号，方便定位；返回的行号以本次读取到的当前分支/提交"
+            "内容为准，不要沿用其他分支或旧提交中的行号。"
+            "如果 start_line 超出当前文件范围，结果会保留原始请求、当前 total_lines"
+            "和 recovery.retry_arguments；请根据 hint 使用新行号重试，工具不会自动重试。"
+            "如果 end_line 超出范围，工具会保留可用内容并在 line_range 中标明"
+            "实际返回范围和 truncated 状态，不会将其视为硬错误。"
         ),
         "parameters": {
             "type": "object",
@@ -114,12 +119,16 @@ READ_FILE_TOOL = {
                     "type": "integer",
                     "description": (
                         "起始行号（从1开始）。仅当需要读取文件特定范围时指定。"
+                        "行号必须依据当前分支/提交的文件内容；若返回越界结果，"
+                        "请按 total_lines、hint 或 recovery.retry_arguments 重新定位。"
                     ),
                 },
                 "end_line": {
                     "type": "integer",
                     "description": (
                         "结束行号（从1开始，包含该行）。仅当需要读取文件特定范围时指定。"
+                        "超出当前文件长度时会截断到实际最后一行，并在返回的"
+                        "line_range 元数据中注明实际范围和 truncated 状态。"
                     ),
                 },
                 "search_pattern": {

--- a/backend/services/ai_reviewer/tools/file_tool.py
+++ b/backend/services/ai_reviewer/tools/file_tool.py
@@ -55,6 +55,9 @@ class _ContentsFetchResult:
         branch_used: 实际读取成功的分支标识（PR 场景为 "HEAD"/"base"，
             非 PR 场景为真实分支名）；全部失败时为 None。
         tried_branches: 已尝试的所有分支标识列表，按尝试顺序记录。
+        ref_used: 实际传给 GitHub API 的 ref（非 PR 场景为分支名，PR
+            场景为 commit SHA）；全部失败时为 None。
+        tried_refs: 已传给 GitHub API 的 ref 列表，按尝试顺序记录。
         error: 失败时的简短错误描述（不含最终返回结构）；成功时为 None。
     """
 
@@ -63,7 +66,9 @@ class _ContentsFetchResult:
         "branch_used",
         "contents",
         "error",
+        "ref_used",
         "tried_branches",
+        "tried_refs",
     )
 
     def __init__(self) -> None:
@@ -71,6 +76,8 @@ class _ContentsFetchResult:
         self.branch_requested: str | None = None
         self.branch_used: str | None = None
         self.tried_branches: list[str] = []
+        self.ref_used: str | None = None
+        self.tried_refs: list[str] = []
         self.error: str | None = None
 
     @property
@@ -129,10 +136,13 @@ class FileToolHandler:
 
         if pr is not None:
             # PR 场景：优先从 HEAD 分支读取，失败则尝试 base 分支
+            head_sha = pr.head.sha
+            result.tried_refs.append(head_sha)
             try:
-                result.contents = repo.get_contents(path, pr.head.sha)
+                result.contents = repo.get_contents(path, head_sha)
                 result.tried_branches.append("HEAD")
                 result.branch_used = "HEAD"
+                result.ref_used = head_sha
                 logger.debug(f"从PR的HEAD分支读取{path_kind}成功: {path}")
                 return result
             except Exception as head_error:
@@ -142,9 +152,12 @@ class FileToolHandler:
                 result.tried_branches.append("HEAD")
 
             try:
-                result.contents = repo.get_contents(path, pr.base.sha)
+                base_sha = pr.base.sha
+                result.tried_refs.append(base_sha)
+                result.contents = repo.get_contents(path, base_sha)
                 result.tried_branches.append("base")
                 result.branch_used = "base"
+                result.ref_used = base_sha
                 logger.debug(f"从PR的base分支读取{path_kind}成功: {path}")
                 return result
             except Exception as base_error:
@@ -169,9 +182,11 @@ class FileToolHandler:
         last_error: str | None = None
         for ref in candidate_refs:
             result.tried_branches.append(ref)
+            result.tried_refs.append(ref)
             try:
                 result.contents = repo.get_contents(path, ref)
                 result.branch_used = ref
+                result.ref_used = ref
                 logger.debug(f"从分支 {ref} 读取{path_kind}成功: {path}")
                 return result
             except Exception as e:
@@ -291,6 +306,8 @@ class FileToolHandler:
                     "branch_requested": branch_requested,
                     "branch_used": branch_used,
                     "tried_branches": tried_branches,
+                    "ref_used": fetch.ref_used,
+                    "tried_refs": fetch.tried_refs,
                 }
 
             # GitHub API returns a list when the path is a directory
@@ -302,6 +319,8 @@ class FileToolHandler:
                     "branch_requested": branch_requested,
                     "branch_used": branch_used,
                     "tried_branches": tried_branches,
+                    "ref_used": fetch.ref_used,
+                    "tried_refs": fetch.tried_refs,
                 }
 
             if content_file.size > MAX_FILE_SIZE_BYTES:
@@ -313,6 +332,8 @@ class FileToolHandler:
                     "tried_branches": tried_branches,
                     "branch_requested": branch_requested,
                     "branch_used": branch_used,
+                    "ref_used": fetch.ref_used,
+                    "tried_refs": fetch.tried_refs,
                     "hint": "请基于PR diff中的patch进行审查，避免读取完整文件",
                 }
 
@@ -330,6 +351,18 @@ class FileToolHandler:
                 end_idx = min(len(lines), end_line)
 
                 if start_idx >= len(lines):
+                    retry_end_line = total_lines
+                    retry_start_line = max(1, total_lines - (end_line - start_line))
+                    retry_arguments: dict[str, Any] = {
+                        "file_path": file_path,
+                        "start_line": retry_start_line,
+                        "end_line": retry_end_line,
+                    }
+                    # 非 PR 场景可以把实际成功读取的回退分支直接用于重试；
+                    # PR 场景的 branch 参数会被忽略，因此改由 ref_used 记录 SHA。
+                    if pr is None and branch_used:
+                        retry_arguments["branch"] = branch_used
+
                     return {
                         "file_path": file_path,
                         "error": f"start_line {start_line} 超出文件范围",
@@ -338,20 +371,69 @@ class FileToolHandler:
                         "branch_requested": branch_requested,
                         "branch_used": branch_used,
                         "tried_branches": tried_branches,
+                        "ref_used": fetch.ref_used,
+                        "tried_refs": fetch.tried_refs,
+                        "line_range": {
+                            "requested": {
+                                "start_line": start_line,
+                                "end_line": end_line,
+                            },
+                            "returned": None,
+                            "total_lines": total_lines,
+                            "status": "start_line_out_of_range",
+                            "start_line_valid": False,
+                            "end_line_valid": end_line <= total_lines,
+                            "truncated": False,
+                            "stale_context_suspected": True,
+                        },
+                        "recovery": {
+                            "action": "retry_read_file",
+                            "automatic_retry": False,
+                            "reason": "start_line_out_of_range",
+                            "retry_arguments": retry_arguments,
+                        },
+                        "hint": (
+                            f"请求范围 start_line={start_line}, end_line={end_line} 超出当前"
+                            f"文件总行数 {total_lines}。行号可能来自已更新的分支或提交，"
+                            "当前行号上下文可能已陈旧。工具未自动重试；请先根据当前文件"
+                            f"重新定位，再重试 read_file（例如 start_line={retry_start_line}, "
+                            f"end_line={retry_end_line}）。"
+                        ),
                     }
 
                 selected_lines = lines[start_idx:end_idx]
+                actual_end_line = min(end_line, total_lines)
+                end_line_truncated = end_line > total_lines
+                range_status = (
+                    "end_line_truncated" if end_line_truncated else "ok"
+                )
+                line_range = {
+                    "requested": {
+                        "start_line": start_line,
+                        "end_line": end_line,
+                    },
+                    "returned": {
+                        "start_line": start_line,
+                        "end_line": actual_end_line,
+                    },
+                    "total_lines": total_lines,
+                    "status": range_status,
+                    "start_line_valid": True,
+                    "end_line_valid": not end_line_truncated,
+                    "truncated": end_line_truncated,
+                    "stale_context_suspected": False,
+                }
                 # 为每行添加行号前缀
                 numbered_content = "\n".join(
                     f"{start_idx + i + 1:>6}\t{line}"
                     for i, line in enumerate(selected_lines)
                 )
-                return {
+                result = {
                     "file_path": file_path,
                     "content": numbered_content,
                     "mode": "line_range",
                     "start_line": start_line,
-                    "end_line": min(end_line, total_lines),
+                    "end_line": actual_end_line,
                     "total_lines": total_lines,
                     "returned_lines": len(selected_lines),
                     "size": content_file.size,
@@ -359,7 +441,18 @@ class FileToolHandler:
                     "branch_requested": branch_requested,
                     "branch_used": branch_used,
                     "tried_branches": tried_branches,
+                    "ref_used": fetch.ref_used,
+                    "tried_refs": fetch.tried_refs,
+                    "line_range": line_range,
                 }
+                if end_line_truncated:
+                    result["hint"] = (
+                        f"请求 end_line={end_line} 超出当前文件总行数 {total_lines}，"
+                        f"已返回当前可用范围 start_line={start_line}, "
+                        f"end_line={actual_end_line}。这是可用结果而非错误；"
+                        "如需读取其他位置，请依据当前文件行号重新请求。"
+                    )
+                return result
 
             # 模式2: 内容搜索
             if search_pattern is not None:
@@ -382,6 +475,8 @@ class FileToolHandler:
                         "branch_requested": branch_requested,
                         "branch_used": branch_used,
                         "tried_branches": tried_branches,
+                        "ref_used": fetch.ref_used,
+                        "tried_refs": fetch.tried_refs,
                     }
 
                 numbered_content = format_search_results(
@@ -402,6 +497,8 @@ class FileToolHandler:
                     "branch_requested": branch_requested,
                     "branch_used": branch_used,
                     "tried_branches": tried_branches,
+                    "ref_used": fetch.ref_used,
+                    "tried_refs": fetch.tried_refs,
                     "hint": (
                         f"共找到 {len(matches)} 处匹配。"
                         f"如需查看更多上下文，可增大 context_lines 参数（当前 {effective_context_lines}）。"
@@ -436,6 +533,8 @@ class FileToolHandler:
                     "branch_requested": branch_requested,
                     "branch_used": branch_used,
                     "tried_branches": tried_branches,
+                    "ref_used": fetch.ref_used,
+                    "tried_refs": fetch.tried_refs,
                 }
 
             # 正常大小文件 - 也添加行号
@@ -453,6 +552,8 @@ class FileToolHandler:
                 "branch_requested": branch_requested,
                 "branch_used": branch_used,
                 "tried_branches": tried_branches,
+                "ref_used": fetch.ref_used,
+                "tried_refs": fetch.tried_refs,
             }
 
         except Exception as e:

--- a/backend/services/issue_analyzer.py
+++ b/backend/services/issue_analyzer.py
@@ -896,6 +896,63 @@ class IssueAnalyzer:
                                 )
                             else:
                                 branch_info = f", 分支={branch_used}"
+                        if tool_call.function.name == "read_file":
+                            line_range = result.get("line_range")
+                            if isinstance(line_range, dict):
+                                range_status = line_range.get("status")
+                                range_truncated = bool(line_range.get("truncated"))
+                                stale_context_suspected = bool(
+                                    line_range.get("stale_context_suspected")
+                                )
+                                requested_range = line_range.get("requested")
+                                returned_range = line_range.get("returned")
+                                start_line_valid = line_range.get(
+                                    "start_line_valid"
+                                )
+                                end_line_valid = line_range.get("end_line_valid")
+                                total_lines = line_range.get("total_lines")
+                            else:
+                                range_status = "error" if result.get("error") else None
+                                range_truncated = False
+                                stale_context_suspected = False
+                                requested_range = None
+                                returned_range = None
+                                start_line_valid = None
+                                end_line_valid = None
+                                total_lines = result.get("total_lines")
+
+                            # 只记录行号/分支定位元数据，不记录工具返回的文件内容、
+                            # hint 或完整错误文本，避免 Issue 内容或凭据进入日志。
+                            if result.get("error") or range_truncated:
+                                recovery = result.get("recovery")
+                                automatic_retry = (
+                                    recovery.get("automatic_retry")
+                                    if isinstance(recovery, dict)
+                                    else None
+                                )
+                                logger.warning(
+                                    "Issue 分析 read_file 行范围追踪: path={}, "
+                                    "status={}, requested={}, returned={}, "
+                                    "total_lines={}, start_line_valid={}, "
+                                    "end_line_valid={}, truncated={}, "
+                                    "stale_context_suspected={}, automatic_retry={}, "
+                                    "branch_requested={}, branch_used={}, ref_used={}, "
+                                    "tried_refs={}",
+                                    result.get("file_path"),
+                                    range_status,
+                                    requested_range,
+                                    returned_range,
+                                    total_lines,
+                                    start_line_valid,
+                                    end_line_valid,
+                                    range_truncated,
+                                    stale_context_suspected,
+                                    automatic_retry,
+                                    result.get("branch_requested"),
+                                    result.get("branch_used"),
+                                    result.get("ref_used"),
+                                    result.get("tried_refs"),
+                                )
                     logger.info(
                         "执行工具 {} (Issue 分析{})",
                         tool_call.function.name,

--- a/tests/test_ai_file_tools_branch.py
+++ b/tests/test_ai_file_tools_branch.py
@@ -213,6 +213,8 @@ async def test_read_file_non_pr_invalid_branch_falls_back(file_strategy):
     assert result["branch_used"] == "main"
     assert result["branch_requested"] == "feature/missing"
     assert result["tried_branches"] == ["feature/missing", "main"]
+    assert result["ref_used"] == "main"
+    assert result["tried_refs"] == ["feature/missing", "main"]
     assert "main-content" in result["content"]
 
 
@@ -263,7 +265,104 @@ async def test_read_file_pr_ignores_branch_uses_head(file_strategy):
 
     assert result["branch_used"] == "HEAD"
     assert result["branch_requested"] is None
+    assert result["ref_used"] == "headsha"
+    assert result["tried_refs"] == ["headsha"]
     assert "head-content" in result["content"]
+
+
+@pytest.mark.asyncio
+async def test_read_file_start_line_out_of_range_returns_recovery_metadata(
+    file_strategy,
+):
+    """行号来自旧上下文时，返回可执行的恢复参数且不伪造自动重试。"""
+    repo = _FakeRepo(
+        branches={
+            "main": {
+                "a.py": _FakeContent(
+                    "a.py", "line 1\nline 2\nline 3\nline 4\nline 5"
+                ),
+            }
+        },
+        default_branch="main",
+    )
+    handler = FileToolHandler()
+
+    result = await handler.read_file(
+        "a.py",
+        repo,
+        pr=None,
+        start_line=10,
+        end_line=12,
+        branch="feature/missing",
+    )
+
+    assert result["error"] == "start_line 10 超出文件范围"
+    assert result["total_lines"] == 5
+    assert result["branch_requested"] == "feature/missing"
+    assert result["branch_used"] == "main"
+    assert result["tried_branches"] == ["feature/missing", "main"]
+    assert result["ref_used"] == "main"
+    assert result["tried_refs"] == ["feature/missing", "main"]
+    assert result["line_range"] == {
+        "requested": {"start_line": 10, "end_line": 12},
+        "returned": None,
+        "total_lines": 5,
+        "status": "start_line_out_of_range",
+        "start_line_valid": False,
+        "end_line_valid": False,
+        "truncated": False,
+        "stale_context_suspected": True,
+    }
+    assert result["recovery"] == {
+        "action": "retry_read_file",
+        "automatic_retry": False,
+        "reason": "start_line_out_of_range",
+        "retry_arguments": {
+            "file_path": "a.py",
+            "start_line": 3,
+            "end_line": 5,
+            "branch": "main",
+        },
+    }
+    assert "工具未自动重试" in result["hint"]
+    assert "start_line=3" in result["hint"]
+    assert "end_line=5" in result["hint"]
+
+
+@pytest.mark.asyncio
+async def test_read_file_end_line_truncation_is_visible_without_error(file_strategy):
+    """结束行越界继续返回内容，但明确暴露请求范围与实际范围。"""
+    repo = _FakeRepo(
+        branches={
+            "main": {
+                "a.py": _FakeContent("a.py", "line 1\nline 2\nline 3"),
+            }
+        },
+        default_branch="main",
+    )
+    handler = FileToolHandler()
+
+    result = await handler.read_file(
+        "a.py", repo, pr=None, start_line=2, end_line=10
+    )
+
+    assert "error" not in result
+    assert result["start_line"] == 2
+    assert result["end_line"] == 3
+    assert result["content"].endswith("line 3")
+    assert result["line_range"] == {
+        "requested": {"start_line": 2, "end_line": 10},
+        "returned": {"start_line": 2, "end_line": 3},
+        "total_lines": 3,
+        "status": "end_line_truncated",
+        "start_line_valid": True,
+        "end_line_valid": False,
+        "truncated": True,
+        "stale_context_suspected": False,
+    }
+    assert "truncation" not in result
+    assert "end_line=10" in result["hint"]
+    assert "end_line=3" in result["hint"]
 
 
 # ── list_directory 非 PR 场景 ────────────────────────────


### PR DESCRIPTION
Add ref_used and tried_refs fields to _ContentsFetchResult so file read responses record the exact refs passed to the GitHub API (commit SHAs in PR HEAD/base scenarios, branch names otherwise), and expose them in the tool response metadata alongside the existing branch fields.

Update the read_file tool description to document that returned line numbers always refer to the current branch/commit, that out-of-range start_line results include total_lines and recovery.retry_arguments for manual retry, and that out-of-range end_line is truncated with the actual range and truncated flag reported in line_range metadata instead of being treated as a hard error.